### PR TITLE
send user straight to pythonhosted.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ LAS-Read-Writer-in-Python
 Laspy is a python library for reading, modifying and creating .LAS LIDAR files. 
 It was designed for python 2.7
 
-API Documentation and tutorials are available at http://www.laspy.org/
+API Documentation and tutorials are available at http://pythonhosted.org/laspy.
 Installation is standard:
 
     >>> python setup.py build


### PR DESCRIPTION
I don't like having to click twice to get to the real docs.
