### PR TITLE
start supporting LAZ natively with lazperf 

### DIFF
--- a/laspy/base.py
+++ b/laspy/base.py
@@ -11,9 +11,9 @@ import copy
 
 def read_compressed(filename):
     import subprocess
-    pathvar1 = any([os.path.isfile(x + "/laszip") 
+    pathvar1 = any([os.path.isfile(x + "/laszip")
             for x in os.environ["PATH"].split(os.pathsep)])
-    pathvar2 = any([os.path.isfile(x + "/laszip.exe") 
+    pathvar2 = any([os.path.isfile(x + "/laszip.exe")
             for x in os.environ["PATH"].split(os.pathsep)])
     if (not pathvar1 and not pathvar2):
         raise(laspy.util.LaspyException("Laszip was not found on the system"))
@@ -28,7 +28,7 @@ def read_compressed(filename):
             print(stderr)
         raise ValueError("Unable to read compressed file!")
     return data
- 
+
 
 class FakeMmap(object):
     '''
@@ -44,37 +44,37 @@ class FakeMmap(object):
 
     def __len__(self):
         return len(self.view)
-    
+
     def __getitem__(self, i):
         return self.view[i]
-    
+
     def close(self):
         self.view = None
-    
+
     def flush(self):
         pass
-    
+
     def seek(self, nbytes, whence=0):
         if whence == 0:
             self.pos = nbytes
         else:
             self.pos += nbytes
 
-            
+
     def read(self, nbytes):
         out = self.view[self.pos:self.pos+nbytes]
         self.pos += nbytes
         return(out)
-        
+
     def tell(self):
         return self.pos
-  
+
 
 
 class DataProvider():
     '''Provides access to the file object, the memory map, and the numpy point map.'''
     def __init__(self, filename, manager):
-        '''Construct the data provider. _mmap refers to the memory map, and _pmap 
+        '''Construct the data provider. _mmap refers to the memory map, and _pmap
         refers to the numpy point map.'''
         self.filename = filename
         self.fileref = False
@@ -98,65 +98,105 @@ class DataProvider():
                 else:
                     self.compressed = False
                 tmpref.close()
-            except Exception as e: 
-                raise laspy.util.LaspyException("Error determining compression: " 
+            except Exception as e:
+                raise laspy.util.LaspyException("Error determining compression: "
                         + str(e))
 
     def open(self, mode):
         '''Open the file, catch simple problems.'''
-        if not self.compressed:
-            try:
-                self.fileref = open(self.filename, mode)
-            except(Exception):
-                raise laspy.util.LaspyException("Error opening file")
+        self.fileref = open(self.filename, mode)
 
     def get_point_map(self, informat):
-        '''Get point map is used to build and return a numpy frombuffer view of the mmapped data, 
-        using a valid laspy.util.Format instance for the desired point format. This method is used 
-        to provide access to extra_bytes even when dimensions have been explicitly defined via an 
+        '''Get point map is used to build and return a numpy frombuffer view of the mmapped data,
+        using a valid laspy.util.Format instance for the desired point format. This method is used
+        to provide access to extra_bytes even when dimensions have been explicitly defined via an
         extra_bytes VLR record.'''
         if type(self._mmap) == bool:
-            self.map() 
+            self.map()
         self.pointfmt = np.dtype([("point", zip([x.name for x in informat.specs],
-                                [x.np_fmt for x in informat.specs]))]) 
-        if not self.manager.header.version in ("1.3", "1.4"): 
-            _pmap = np.frombuffer(self._mmap, self.pointfmt, 
+                                [x.np_fmt for x in informat.specs]))])
+        if not self.manager.header.version in ("1.3", "1.4"):
+            _pmap = np.frombuffer(self._mmap, self.pointfmt,
                         offset = self.manager.header.data_offset)
-        else:  
-            _pmap = np.frombuffer(self._mmap, self.pointfmt, 
+        else:
+            _pmap = np.frombuffer(self._mmap, self.pointfmt,
                         offset = self.manager.header.data_offset,
                         count = self.manager.header.point_records_count)
         return(_pmap)
 
+    def findLASzipVLR(self, vlrs):
+        for vlr in vlrs:
+            if vlr.user_id.rstrip(' \t\r\n\0') == 'laszip encoded':
+                if vlr.record_id == 22204:
+                    return vlr
+        return None
 
     def point_map(self):
-        '''Create the numpy point map based on the point format.'''   
+        '''Create the numpy point map based on the point format.'''
         if type(self._mmap) == bool:
-            self.map() 
+            self.map()
         self.pointfmt = np.dtype([("point", zip([x.name for x in self.manager.point_format.specs],
-                                [x.np_fmt for x in self.manager.point_format.specs]))]) 
-        if not self.manager.header.version in ("1.3", "1.4"): 
-            self._pmap = np.frombuffer(self._mmap, self.pointfmt, 
+                                [x.np_fmt for x in self.manager.point_format.specs]))])
+        if not self.manager.header.version in ("1.3", "1.4"):
+
+            if self.compressed:
+                import lazperf
+                from lazperf import VLRDecompressor
+                vlr = self.findLASzipVLR(self.manager.header.vlrs)
+                vlr_data = np.frombuffer(vlr.VLR_body, np.uint8, count=vlr.rec_len_after_header)
+                if not vlr:
+                    raise laspy.util.LaspyException("""Unable to find LASzip VLR!""")
+                # first 8 bytes after VLRs are laszip, then is start of data
+                laszip_offset = self.manager.header.data_offset + 8
+                points_compressed = np.frombuffer(self._mmap, np.uint8, offset=laszip_offset, count=self._mmap.size() - laszip_offset)
+
+                point_uncompressed = np.zeros(self.manager.header.records_count * self.manager.header.data_record_length, dtype=np.uint8)
+                import pdb;pdb.set_trace()
+
+                #
+                decompressor = lazperf.VLRDecompressor(points_compressed, vlr_data)
+                point_buffer = np.zeros(self.manager.header.data_record_length, dtype=np.uint8)
+                begin = 0
+                point_length = self.manager.header.data_record_length
+                for r in range(self.manager.header.records_count):
+                    decompressor.decompress(point_buffer)
+                    end = begin + point_length
+                    point_uncompressed[begin : end] = point_buffer
+                    begin = end
+#                    break
+
+                # copy raw header onto here and then tack on uncomrpessed points
+                header = np.frombuffer(self._mmap, np.uint8, count = self.manager.header.data_offset)
+                full = np.zeros(len(header) + len(point_uncompressed), dtype=np.uint8)
+                import pdb;pdb.set_trace()
+                full[0:len(header)] = header
+                full[len(header):len(point_uncompressed)+len(header)] = point_uncompressed
+
+                self._mmap = full
+
+
+
+            self._pmap = np.frombuffer(self._mmap, self.pointfmt,
                         offset = self.manager.header.data_offset)
             if self.manager.header.point_records_count != len(self._pmap):
                 if self.manager.mode == "r":
-                    raise laspy.util.LaspyException("""Invalid Point Records Count Information Encountered in Header. 
+                    raise laspy.util.LaspyException("""Invalid Point Records Count Information Encountered in Header.
                                         Please correct. Header.point_records_count = %i, and %i records actually detected."""%(self.manager.header.point_records_count, len(self._pmap)))
                 else:
-                    print("""WARNING: laspy found invalid data in header.point_records_count. 
-                            Header.point_records_count = %i, and %i records actually detected. 
+                    print("""WARNING: laspy found invalid data in header.point_records_count.
+                            Header.point_records_count = %i, and %i records actually detected.
                             Attempting to correct mismatch.""")%(self.manager.header.point_records_count, len(self._pmap))
                     self.manager.header.point_records_count = len(self._pmap)
-        else:  
-            self._pmap = np.frombuffer(self._mmap, self.pointfmt, 
+        else:
+            self._pmap = np.frombuffer(self._mmap, self.pointfmt,
                         offset = self.manager.header.data_offset,
                         count = self.manager.header.point_records_count)
-      
 
-    
+
+
     def close(self, flush = True):
-        '''Close the data provider and flush changes if _mmap and _pmap exist.''' 
-        if flush and self.manager.has_point_records: 
+        '''Close the data provider and flush changes if _mmap and _pmap exist.'''
+        if flush and self.manager.has_point_records:
             if type(self._mmap) != bool:
                 try:
                     self._mmap.flush()
@@ -179,27 +219,27 @@ class DataProvider():
             raise laspy.util.LaspyException("File not opened.")
         try:
             if self.mode == "r":
-                if self.compressed:
-                    self._mmap=FakeMmap(self.filename)
-                else:
-                    self._mmap = mmap.mmap(self.fileref.fileno(), 0, access = mmap.ACCESS_READ)
+#                 if self.compressed:
+#                     self._mmap=FakeMmap(self.filename)
+#                 else:
+                self._mmap = mmap.mmap(self.fileref.fileno(), 0, access = mmap.ACCESS_READ)
             elif self.mode in ("w", "rw"):
                 self._mmap = mmap.mmap(self.fileref.fileno(), 0, access = mmap.ACCESS_WRITE)
             else:
                 raise laspy.util.LaspyException("Invalid Mode: " + str(self.mode))
-        except Exception as e: 
+        except Exception as e:
             raise laspy.util.LaspyException("Error mapping file: " + str(e))
 
     def remap(self,flush = True, point_map = False):
         '''Re-map the file. Flush changes, close, open, and map. Optionally point map.'''
-        if flush and type(self._mmap) != bool: 
-            self._mmap.flush() 
+        if flush and type(self._mmap) != bool:
+            self._mmap.flush()
         self.close(flush=False)
         self.open("r+b")
         self.map()
-        if point_map: 
+        if point_map:
             self.point_map()
-   
+
     def __getitem__(self, index):
         '''Return the raw bytes corresponding to the point @ index.'''
         try:
@@ -228,23 +268,23 @@ class DataProvider():
         return(self._mmap.size())
 
 class FileManager():
-    '''Superclass of Reader and Writer, provides most of the data manipulation functionality in laspy.''' 
-    def __init__(self,filename, mode, header = False, vlrs = False, evlrs = False): 
+    '''Superclass of Reader and Writer, provides most of the data manipulation functionality in laspy.'''
+    def __init__(self,filename, mode, header = False, vlrs = False, evlrs = False):
         '''Build the FileManager object. This is done when opening the file
-        as well as upon completion of file modification actions like changing the 
+        as well as upon completion of file modification actions like changing the
         header padding.'''
         self.compressed = False
         self.vlr_formats = laspy.util.Format("VLR")
         self.evlr_formats = laspy.util.Format("EVLR")
         self.mode = mode
-        self.data_provider = DataProvider(filename, self) 
+        self.data_provider = DataProvider(filename, self)
         self.setup_memoizing()
-        
+
         self.calc_point_recs = False
 
         self.point_refs = False
-        self._current = 0 
-        
+        self._current = 0
+
         self.padded = False
         if self.mode == "r":
             self.setup_read_write(vlrs,evlrs, read_only=True)
@@ -257,7 +297,7 @@ class FileManager():
             return
         else:
             raise laspy.util.LaspyException("Append Mode Not Supported")
-        
+
     def setup_read_write(self, vlrs, evlrs, read_only=True):
         # Check if read only mode, if not open for updating.
         if read_only:
@@ -266,20 +306,20 @@ class FileManager():
             open_mode = "r+b"
         self._header_current = True
         self.data_provider.open(open_mode)
-        self.data_provider.map() 
+        self.data_provider.map()
         self.header_format = laspy.util.Format("h" + self.grab_file_version())
         self.get_header(self.grab_file_version())
         self.populate_vlrs()
         self.point_refs = False
         self.has_point_records = True
-        self._current = 0        
+        self._current = 0
         self.correct_rec_len()
 
         if self.point_format.compressed:
             self.compressed = True
             self.data_provider.remap()
         else:
-            self.compressed = False        
+            self.compressed = False
 
         self.data_provider.point_map()
         if self.header.version in ("1.3", "1.4"):
@@ -301,7 +341,7 @@ class FileManager():
         elif len(eb_vlrs) == 1:
             self.naive_point_format = self.point_format
             self.extra_dimensions = eb_vlrs[0].extra_dimensions
-            new_pt_fmt = laspy.util.Format(self.point_format.fmt, extradims 
+            new_pt_fmt = laspy.util.Format(self.point_format.fmt, extradims
                     = self.extra_dimensions)
             self.point_format = new_pt_fmt
             self.data_provider.remap(point_map = True)
@@ -313,8 +353,8 @@ class FileManager():
             raise laspy.util.LaspyException("Write mode requires a valid header object.")
         ## No file to store data yet.
         self.has_point_records = False
-        self.data_provider.open("w+b") 
-        self.header_format = header.format 
+        self.data_provider.open("w+b")
+        self.header_format = header.format
         self._header = header
         self.header = laspy.header.HeaderManager(header = header, reader = self)
         self.initialize_file_padding(vlrs)
@@ -322,7 +362,7 @@ class FileManager():
         ## We have a file to store data now.
         self.data_provider.remap()
         self.header.flush()
-        
+
         self.correct_rec_len()
         if not vlrs in [[], False]:
             self.set_vlrs(vlrs)
@@ -334,7 +374,7 @@ class FileManager():
             self.evlrs = []
         self.verify_num_vlrs()
         if self._header.created_year == 0:
-            self.header.date = datetime.datetime.now() 
+            self.header.date = datetime.datetime.now()
         self.populate_vlrs()
         self.populate_evlrs()
         # If extra-bytes descriptions exist in VLRs, use them.
@@ -346,7 +386,7 @@ class FileManager():
         elif len(eb_vlrs) == 1:
             self.naive_point_format = self.point_format
             self.extra_dimensions = eb_vlrs[0].extra_dimensions
-            new_pt_fmt = laspy.util.Format(self.point_format.fmt, extradims 
+            new_pt_fmt = laspy.util.Format(self.point_format.fmt, extradims
                     = self.extra_dimensions)
             self.point_format = new_pt_fmt
         return
@@ -355,18 +395,18 @@ class FileManager():
         headervlrs = self.get_header_property("num_variable_len_recs")
         calc_headervlrs = len(self.vlrs)
         if headervlrs != calc_headervlrs:
-            raise laspy.util.LaspyException('''Number of EVLRs provided does not match the number 
-                                 specified in the header. (copied headers do not maintain 
-                                 references to their EVLRs, that might be your problem. 
+            raise laspy.util.LaspyException('''Number of EVLRs provided does not match the number
+                                 specified in the header. (copied headers do not maintain
+                                 references to their EVLRs, that might be your problem.
                                  You can pass them explicitly to the File constructor.)''')
 
         if self.header.version == "1.4":
             calc_headerevlrs = len(self.evlrs)
             headerevlrs = self.get_header_property("num_evlrs")
             if headerevlrs != calc_headerevlrs:
-                raise laspy.util.LaspyException('''Number of EVLRs provided does not match the number 
-                                     specified in the header. (copied headers do not maintain 
-                                     references to their EVLRs, that might be your problem. 
+                raise laspy.util.LaspyException('''Number of EVLRs provided does not match the number
+                                     specified in the header. (copied headers do not maintain
+                                     references to their EVLRs, that might be your problem.
                                      You can pass them explicitly to the File constructor.)''')
     def correct_rec_len(self):
         extrabytes = self.header.data_record_length-laspy.util.Format(self.header.data_format_id).rec_len
@@ -374,7 +414,7 @@ class FileManager():
             self.point_format = laspy.util.Format(self.header.data_format_id,extra_bytes= extrabytes)
         else:
             self.point_format = laspy.util.Format(self.header.data_format_id)
-            self.set_header_property("data_record_length", self.point_format.rec_len) 
+            self.set_header_property("data_record_length", self.point_format.rec_len)
 
     def initialize_file_padding(self, vlrs):
         filesize = self._header.format.rec_len
@@ -384,7 +424,7 @@ class FileManager():
         self.vlr_stop = filesize
         if self._header.data_offset != 0:
             filesize = max(self._header.data_offset, filesize)
-        self._header.data_offset = filesize 
+        self._header.data_offset = filesize
         self.data_provider.fileref.write("\x00"*filesize)
         return
 
@@ -411,19 +451,19 @@ class FileManager():
         if padding < 0:
             raise laspy.util.LaspyException("Invalid Data: Packed Length is Greater than allowed.")
         return(raw_bin + '0'*(zerolen-len(raw_bin)))
-    
+
     def bit_transform(self, x, low, high):
         return np.right_shift(np.bitwise_and(x, 2**high - 1), low)
 
     def read(self, bytes):
         '''Wrapper for mmap.mmap read function'''
         return(self.data_provider._mmap.read(bytes))
-    
+
     def reset(self):
         '''Refresh the mmap and fileref'''
-        self.data_provier.remap() 
+        self.data_provier.remap()
         return
-     
+
     def seek(self, bytes, rel = True):
         '''Wrapper for mmap.mmap seek functions, make option rel explicit'''
         self._current = None
@@ -431,9 +471,9 @@ class FileManager():
             self.data_provider._mmap.seek(bytes,1)
             return
         self.data_provider._mmap.seek(bytes, 0)
-        
+
     def read_words(self, name, rec_type = "vlr"):
-        '''Read a consecutive sequence of packed binary data, return a single 
+        '''Read a consecutive sequence of packed binary data, return a single
         element or list.'''
         if rec_type == "vlr":
             source = self.vlr_formats
@@ -446,12 +486,12 @@ class FileManager():
         try:
             dim = source.lookup[name]
         except KeyError:
-            raise laspy.util.LaspyException("Dimension " + name + " not found.")       
+            raise laspy.util.LaspyException("Dimension " + name + " not found.")
         return(self._read_words(dim.fmt, dim.num, dim.length))
 
     def _read_words(self, fmt, num, bytes):
         '''Read a consecutive sequence of packed binary data, return a single
-        element or list''' 
+        element or list'''
         outData = []
         for i in xrange(num):
             dat = self.read(bytes)
@@ -459,7 +499,7 @@ class FileManager():
         if len(outData) > 1:
             return(outData)
         return(outData[0])
-    
+
     def _pack_words(self, fmt, num, bytes, val):
         if num == 1:
             return(struct.pack(fmt, val))
@@ -480,18 +520,18 @@ class FileManager():
         ## Why is this != neccesary?
         try:
             return(self.header)
-        except: 
+        except:
             self.header = laspy.header.HeaderManager(header = laspy.header.Header(file_version), reader = self)
             return(self.header)
 
-    def populate_evlrs(self): 
+    def populate_evlrs(self):
         '''Catalogue the extended variable length records'''
         self.evlrs = []
-      
+
         if not self.header.version in ("1.3", "1.4"):
             return
-        
-       
+
+
         if self.header.version == "1.3":
             if self.header.start_wavefm_data_rec != 0:
                 self.seek(self.header.start_wavefm_data_rec, rel = False)
@@ -501,18 +541,18 @@ class FileManager():
         elif self.header.version == "1.4":
             self.seek(self.header.start_first_evlr, rel = False)
             num_vlrs = self.get_header_property("num_evlrs")
-        for i in xrange(num_vlrs): 
+        for i in xrange(num_vlrs):
             new_vlr = laspy.header.EVLR(None, None, None)
             new_vlr.build_from_reader(self)
-            self.evlrs.append(new_vlr)  
+            self.evlrs.append(new_vlr)
         return
 
 
-    def populate_vlrs(self): 
+    def populate_vlrs(self):
         '''Catalogue the variable length records'''
         self.vlrs = []
         self.seek(self.header.header_size, rel = False)
-        for i in xrange(self.get_header_property("num_variable_len_recs")): 
+        for i in xrange(self.get_header_property("num_variable_len_recs")):
             new_vlr = laspy.header.VLR(None, None, None)
             new_vlr.build_from_reader(self)
             self.vlrs.append(new_vlr)
@@ -530,7 +570,7 @@ class FileManager():
         except:
             self.populate_vlrs()
             return(self.vlrs)
-    
+
     def push_vlrs(self):
         self.set_vlrs(self.vlrs)
 
@@ -552,15 +592,15 @@ class FileManager():
 
     def set_input_srs(self):
         pass
-    
+
     def set_output_srsS(self):
         pass
 
     def get_raw_point_index(self,index):
         '''Return the byte index of point number index'''
-        return(self.header.data_offset + 
+        return(self.header.data_offset +
             index*self.header.data_record_length)
-    
+
     def get_points(self):
         '''Return a numpy array of all point data in a file.'''
         if not self.has_point_records:
@@ -575,10 +615,10 @@ class FileManager():
         #return([laspy.util.Point(self,x) for x in self._get_raw_dimension(0, self.header.data_record_length)])
         #return((x[0] for x in self.data_provider._pmap))
         return(self.data_provider._pmap)
-    
+
     def get_raw_point(self, index):
         '''Return the raw bytestring associated with point of number index'''
-        #start = (self.header.data_offset + 
+        #start = (self.header.data_offset +
         #    index * self.header.data_record_length)
         #return(self.data_provider._mmap[start : start +
         #     self.header.data_record_length])
@@ -587,17 +627,17 @@ class FileManager():
 
 #self, reader, startIdx ,version
     def get_point(self, index, nice=False):
-        '''Return point object for point of number index / #legacy_api''' 
+        '''Return point object for point of number index / #legacy_api'''
         if index >= self.get_pointrecordscount():
-            return 
+            return
         self._current = index
         return(laspy.util.Point(self, self.get_raw_point(index), nice= nice))
 
-    
+
     def get_next_point(self):
         '''Return next point object via get_point / #legacy_api'''
         if self._current == None:
-            raise laspy.util.LaspyException("No Current Point Specified," + 
+            raise laspy.util.LaspyException("No Current Point Specified," +
                             " use Reader.GetPoint(0) first")
         if self._current == self.get_pointrecordscount():
             return
@@ -613,7 +653,7 @@ class FileManager():
         return
 
     def get_dimension(self, name):
-        '''Grab a point dimension by name, returning a numpy array. Refers to 
+        '''Grab a point dimension by name, returning a numpy array. Refers to
         reader.point_format for the required Spec instance.'''
         if not self.has_point_records:
             return None
@@ -621,21 +661,21 @@ class FileManager():
         #    self.build_point_refs()
         if type(self.data_provider._pmap) == bool:
             self.data_provider.point_map()
-        try: 
+        try:
             spec = self.point_format.lookup[name]
             #return(self._get_dimension(spec))
             return(self._get_dimension(spec))
         except KeyError:
-            raise laspy.util.LaspyException("Dimension: " + str(name) + 
+            raise laspy.util.LaspyException("Dimension: " + str(name) +
                             " not found.")
-    
+
     def _get_dimension(self, spec):
         return(self.data_provider._pmap["point"][spec.name])
 
     def _get_dimension_by_specs(self,offs, fmt, length):
-        '''Return point dimension of specified offset format and length''' 
-        _mmap = self.data_provider._mmap  
-        prefs = (offs + x for x in self.point_refs) 
+        '''Return point dimension of specified offset format and length'''
+        _mmap = self.data_provider._mmap
+        prefs = (offs + x for x in self.point_refs)
         packer = self.c_packers[fmt]
         return((packer.unpack(_mmap[x:x+length])[0] for x in prefs))
 
@@ -643,36 +683,36 @@ class FileManager():
 
 
     def _get_raw_dimension(self,spec):
-        '''Return point dimension of specified offset format and length''' 
-        #_mmap = self.data_provider._mmap 
+        '''Return point dimension of specified offset format and length'''
+        #_mmap = self.data_provider._mmap
         #prefs = (offs + x for x in self.point_refs)
         #return((_mmap[start + offs : start+offs+length] for start in prefs))
         return(self.data_provider._pmap["point"][spec.name].tostring())
 
     def _get_raw_datum(self, rec_offs, spec):
         '''return raw bytes associated with non dimension field (VLR/Header)'''
-        return(self.data_provider._mmap[(rec_offs + spec.offs):(rec_offs + spec.offs 
-                        + spec.num*spec.length)]) 
+        return(self.data_provider._mmap[(rec_offs + spec.offs):(rec_offs + spec.offs
+                        + spec.num*spec.length)])
 
     def _get_datum(self, rec_offs, spec):
-        '''Return unpacked data assocaited with non dimension field (VLR/Header)''' 
+        '''Return unpacked data assocaited with non dimension field (VLR/Header)'''
         data = self._get_raw_datum(rec_offs, spec)
         if spec.num == 1:
             return(struct.unpack(spec.fmt, data)[0])
-        unpacked = map(lambda x: struct.unpack(spec.fmt, 
+        unpacked = map(lambda x: struct.unpack(spec.fmt,
             data[x*spec.length:(x+1)*spec.length])[0], xrange(spec.num))
         if spec.pack:
             return("".join([str(x[0]) for x in unpacked]))
-        return(unpacked) 
+        return(unpacked)
 
     def get_raw_header_property(self, name):
         '''Wrapper for grabbing raw header bytes with _get_raw_datum'''
         spec = self.header_format.lookup[name]
 
         return(self._get_raw_datum(0, spec))
-    
+
     def get_header_property(self, name):
-        '''Wrapper for grabbing unpacked header data with _get_datum''' 
+        '''Wrapper for grabbing unpacked header data with _get_datum'''
         #print name
         if name in self.header_changes:
             spec = self.header_format.lookup[name]
@@ -687,7 +727,7 @@ class FileManager():
             val = self._get_datum(0, spec)
             self.header_properties[name] = val
             return(val)
-    
+
     def get_x(self, scale=False):
         if not scale:
             return(self.get_dimension("X"))
@@ -702,17 +742,17 @@ class FileManager():
         if not scale:
             return(self.get_dimension("Z"))
         return(self.get_dimension("Z")*self.header.scale[2] + self.header.offset[2])
-    
+
     def get_intensity(self):
         return(self.get_dimension("intensity"))
-    
+
     def get_flag_byte(self):
         return(self.get_dimension("flag_byte"))
-   
+
     def get_raw_classification_flags(self):
         return(self.get_dimension("classification_flags"))
 
-    def get_classification_flags(self): 
+    def get_classification_flags(self):
         if not self.header.data_format_id in (6,7,8,9,10):
             return(self.get_classification())
         rawDim = self.get_raw_classification_flags()
@@ -748,17 +788,17 @@ class FileManager():
             rawDim = self.get_raw_classification_flags()
         return self.bit_transform(rawDim, 6, 7)
 
-    def get_edge_flight_line(self): 
+    def get_edge_flight_line(self):
         if self.header.data_format_id in (0,1,2,3,4,5):
-            rawDim = self.get_flag_byte() 
+            rawDim = self.get_flag_byte()
         elif self.header.data_format_id in (6,7,8,9,10):
-            rawDim = self.get_raw_classification_flags() 
+            rawDim = self.get_raw_classification_flags()
         return self.bit_transform(rawDim, 7, 8)
-    
+
     def get_raw_classification(self):
         return(self.get_dimension("raw_classification"))
-    
-    def get_classification(self): 
+
+    def get_classification(self):
         if self.header.data_format_id in (0,1,2,3,4,5):
             return self.bit_transform(self.get_raw_classification(), 0, 5)
         elif self.header.data_format_id in (6,7,8,9,10):
@@ -781,7 +821,7 @@ class FileManager():
             return self.bit_transform(self.get_raw_classification_flags(), 2, 3)
 
         return self.bit_transform(self.get_raw_classification(), 7, 8)
-    
+
     def get_overlap(self):
         if self.header.data_format_id in (6,7,8,9,10):
             return self.bit_transform(self.get_raw_classification_flags(), 3, 4)
@@ -790,22 +830,22 @@ class FileManager():
 
     def get_scan_angle_rank(self):
         return(self.get_dimension("scan_angle_rank"))
-    
+
     def get_user_data(self):
         return(self.get_dimension("user_data"))
-    
+
     def get_pt_src_id(self):
         return(self.get_dimension("pt_src_id"))
-    
+
     def get_gps_time(self):
         return(self.get_dimension("gps_time"))
 
     def get_red(self):
         return(self.get_dimension("red"))
-    
+
     def get_green(self):
         return(self.get_dimension("green"))
- 
+
     def get_blue(self):
         return(self.get_dimension("blue"))
 
@@ -839,7 +879,7 @@ class FileManager():
         if "extra_bytes" in self.point_format.lookup.keys():
             return(self.get_dimension("extra_bytes"))
         elif self.extra_dimensions != []:
-            newmap = self.data_provider.get_point_map(self.naive_point_format) 
+            newmap = self.data_provider.get_point_map(self.naive_point_format)
             return(newmap["point"]["extra_bytes"])
         else:
             raise laspy.util.LaspyException("Extra bytes not present in record")
@@ -848,27 +888,27 @@ class FileManager():
 class Reader(FileManager):
     def close(self):
         '''Close the file.'''
-        self.data_provider.close() 
-    
+        self.data_provider.close()
+
 class Writer(FileManager):
 
     def close(self, ignore_header_changes = False, minmax_mode = "scaled"):
-        '''Flush changes to mmap and close mmap and fileref''' 
+        '''Flush changes to mmap and close mmap and fileref'''
         if (not ignore_header_changes) and (self.has_point_records):
             if not self._header_current:
                 self.header.update_histogram()
-            self.header.update_min_max(minmax_mode) 
+            self.header.update_min_max(minmax_mode)
         self.data_provider.close()
-   
+
     def set_evlrs(self, value):
         if value == False or len(value) == 0:
             return
         if not all([x.isEVLR for x in value]):
-            raise laspy.util.LaspyException("set_evlrs requers an iterable object " + 
+            raise laspy.util.LaspyException("set_evlrs requers an iterable object " +
                         "composed of :obj:`laspy.header.EVLR` objects.")
         elif self.mode == "w+":
             raise NotImplementedError
-        elif self.mode in ("rw", "w"): 
+        elif self.mode in ("rw", "w"):
             if self.header.version == "1.3":
                 old_offset = self.header.start_wavefm_data_rec
             elif self.header.version == "1.4":
@@ -877,7 +917,7 @@ class Writer(FileManager):
             else:
                 raise laspy.util.LaspyException("Invalid File Version for EVLRs: " + str(self.header.version))
             # Good we know where the EVLRs should go... but what about if we don't have point records yet?
-            # We can't make that decision yet, in case the user wants to subset the data. 
+            # We can't make that decision yet, in case the user wants to subset the data.
             if not self.has_point_records:
                 old_offset = self.header.data_offset
                 if self.header.version == "1.3":
@@ -906,13 +946,13 @@ class Writer(FileManager):
             self.data_provider.open("w+b")
             self.data_provider.fileref.write(dat_part_1)
             total_evlrs = sum([len(x) for x in value])
-            self.data_provider.fileref.write("\x00"*total_evlrs) 
+            self.data_provider.fileref.write("\x00"*total_evlrs)
             self.data_provider.fileref.close()
             self.data_provider.open("r+b")
             self.data_provider.map()
             self.seek(old_offset, rel = False)
 
-            for evlr in value: 
+            for evlr in value:
                 self.data_provider._mmap.write(evlr.to_byte_string())
 
             if self.has_point_records:
@@ -920,22 +960,22 @@ class Writer(FileManager):
             self.populate_evlrs()
 
         else:
-            raise(laspy.util.LaspyException("set_evlrs requires the file to be opened in a " + 
-                "write mode, and must be performed before point information is provided." + 
+            raise(laspy.util.LaspyException("set_evlrs requires the file to be opened in a " +
+                "write mode, and must be performed before point information is provided." +
                 "Try closing the file and opening it in rw mode. "))
- 
+
     def save_vlrs(self):
         self.set_vlrs(self.vlrs)
 
-    def set_vlrs(self, value): 
+    def set_vlrs(self, value):
         if value == False or len(value) == 0:
             return
         if not all([x.isVLR for x in value]):
-            raise laspy.util.LaspyException("set_vlrs requers an iterable object " + 
+            raise laspy.util.LaspyException("set_vlrs requers an iterable object " +
                         "composed of :obj:`laspy.header.VLR` objects.")
         elif self.mode == "w+":
             raise NotImplementedError
-        elif self.mode == "rw": 
+        elif self.mode == "rw":
             current_size = self.data_provider._mmap.size()
             current_padding = self.get_padding()
             old_offset = self.header.data_offset
@@ -960,13 +1000,13 @@ class Writer(FileManager):
             self.data_provider.map()
             self.data_provider.point_map()
             self.populate_vlrs()
-        elif self.mode == "w" and not self.has_point_records: 
+        elif self.mode == "w" and not self.has_point_records:
 
             self.set_header_property("num_variable_len_recs", len(value))
-            if (self.data_provider._mmap.size() < self.header.header_size + sum([len(x) for x in value])): 
+            if (self.data_provider._mmap.size() < self.header.header_size + sum([len(x) for x in value])):
                 old_offset = self.header.header_size
                 self.data_provider.fileref.seek(0, 0)
-                dat_part_1 = self.data_provider.fileref.read(self.header.header_size) 
+                dat_part_1 = self.data_provider.fileref.read(self.header.header_size)
                 # Manually Close:
                 self.data_provider.close(flush=False)
                 self.data_provider.open("w+b")
@@ -1011,12 +1051,12 @@ class Writer(FileManager):
             self.data_provider.open("r+b")
             self.data_provider.map()
             self.data_provider.point_map()
-            self.populate_vlrs() 
+            self.populate_vlrs()
 
 
     def set_padding(self, value):
         '''Set the padding between end of VLRs and beginning of point data'''
-        if value < 0: 
+        if value < 0:
             raise laspy.util.LaspyException("New Padding Value Overwrites VLRs")
         if self.mode == "w":
             if not self.has_point_records:
@@ -1030,41 +1070,41 @@ class Writer(FileManager):
             old_offset = self.header.data_offset
             self.set_header_property("data_offset",
                                             self.vlr_stop +  value)
-            #self.header.data_offset = self.vlr_stop + value 
-            self.data_provider._mmap.flush() 
+            #self.header.data_offset = self.vlr_stop + value
+            self.data_provider._mmap.flush()
             self.seek(0, rel=False)
             dat_part_1 = self.data_provider._mmap.read(self.vlr_stop)
             self.seek(old_offset, rel = False)
-            dat_part_2 = self.data_provider._mmap.read(len(self.data_provider._mmap) - old_offset) 
-            self.data_provider.close() 
-            self.data_provider.open("w+b") 
-            self.data_provider.fileref.write(dat_part_1) 
+            dat_part_2 = self.data_provider._mmap.read(len(self.data_provider._mmap) - old_offset)
+            self.data_provider.close()
+            self.data_provider.open("w+b")
+            self.data_provider.fileref.write(dat_part_1)
             self.data_provider.fileref.write("\x00"*value)
             self.data_provider.fileref.write(dat_part_2)
             self.data_provider.close()
-            self.__init__(self.data_provider.filename, self.mode) 
+            self.__init__(self.data_provider.filename, self.mode)
             return(len(self.data_provider._mmap))
         elif self.mode == "r+":
             pass
         else:
             raise(laspy.util.LaspyException("Must be in write mode to change padding."))
         return(len(self.data_provider._mmap))
-    
-    def pad_file_for_point_recs(self,num_recs): 
-        '''Pad the file with null bytes out to a calculated length based on 
-        the data given. This is usually a side effect of set_dimension being 
+
+    def pad_file_for_point_recs(self,num_recs):
+        '''Pad the file with null bytes out to a calculated length based on
+        the data given. This is usually a side effect of set_dimension being
         called for the first time on a file in write mode. '''
 
         bytes_to_pad = num_recs * self.point_format.rec_len
         self.header.point_records_count = num_recs
         if self.evlrs in [False, []]:
             #old_size = self.data_provider.filesize()
-            old_size = self.header.data_offset     
+            old_size = self.header.data_offset
             self.data_provider._mmap.flush()
             self.data_provider.fileref.seek(old_size, 0)
             self.data_provider.fileref.write("\x00" * (bytes_to_pad))
             self.data_provider.fileref.flush()
-            self.data_provider.remap(flush = False, point_map = True) 
+            self.data_provider.remap(flush = False, point_map = True)
             # Write Phase complete, enter rw mode?
             self.padded = num_recs
             return
@@ -1081,7 +1121,7 @@ class Writer(FileManager):
             self.header.start_wavefm_data_rec += bytes_to_pad
             if self.header.version == "1.4":
                 self.header.start_first_evlr += bytes_to_pad
-        
+
     def define_new_dimension(self,name, data_type,description = ""):
         old_vlrs = self.vlrs
         if self.has_point_records or not self.mode == "w":
@@ -1098,13 +1138,13 @@ class Writer(FileManager):
             raise laspy.util.LaspyException("Adding a dimension is ambiguous when there are already extra bytes in the point records, but no VLR describing them.")
         new_dimension = laspy.header.ExtraBytesStruct(name = name, data_type = data_type, description = description)
         if len(eb_vlrs) + len(eb_evlrs) > 1:
-            raise laspy.util.LaspyException("Only one ExtraBytes VLR currently allowed.") 
+            raise laspy.util.LaspyException("Only one ExtraBytes VLR currently allowed.")
         elif len(eb_vlrs) + len(eb_evlrs) == 1:
             if len(eb_vlrs) == 1:
                 extra_dimensions = eb_vlrs[0].extra_dimensions
                 extra_dimensions.append(new_dimension)
                 self.extra_dimensions = extra_dimensions
-                new_pt_fmt = laspy.util.Format(self.point_format.fmt, extradims 
+                new_pt_fmt = laspy.util.Format(self.point_format.fmt, extradims
                              = extra_dimensions)
                 self.point_format = new_pt_fmt
                 self.set_header_property("data_record_length", self.point_format.rec_len)
@@ -1112,33 +1152,33 @@ class Writer(FileManager):
                 eb_vlr_index = [x for x in range(len(self.vlrs)) if self.vlrs[x].type == 1][0]
                 new_vlr = copy.copy(eb_vlrs[0])
                 nvlrbs = new_dimension.to_byte_string()
-                new_vlr.VLR_body += nvlrbs 
+                new_vlr.VLR_body += nvlrbs
                 new_vlr.rec_len_after_header += len(nvlrbs)
-                old_vlrs[eb_vlr_index] = new_vlr 
+                old_vlrs[eb_vlr_index] = new_vlr
                 self.set_vlrs(old_vlrs)
                 self.populate_vlrs()
             elif len(eb_evlrs) == 1:
                 extra_dimensions = eb_evlrs[0].extra_dimensions
                 extra_dimensions.append(new_dimension)
                 self.extra_dimensions = extra_dimensions
-                new_pt_fmt = laspy.util.Format(self.point_format.fmt, extradims 
+                new_pt_fmt = laspy.util.Format(self.point_format.fmt, extradims
                              = extra_dimensions)
                 self.point_format = new_pt_fmt
                 self.set_header_property("data_record_length", self.point_format.rec_len)
                 eb_evlr_index = [x for x in range(len(self.evlrs)) if self.evlrs[x].type == 1][0]
                 new_vlr = copy.copy(eb_evlrs[0])
                 nvlrbs = new_dimension.to_byte_string()
-                new_vlr.VLR_body += nvlrbs 
+                new_vlr.VLR_body += nvlrbs
                 new_vlr.rec_len_after_header += len(nvlrbs)
-                old_vlrs[eb_evlr_index] = new_vlr 
+                old_vlrs[eb_evlr_index] = new_vlr
                 self.set_evlrs(old_evlrs)
                 self.populate_evlrs()
         else:
             # There are no current extra dimensions.
             new_vlr = laspy.header.VLR(user_id = "LASF_Spec", record_id = 4, VLR_body = new_dimension.to_byte_string())
-            old_vlrs.append(new_vlr) 
+            old_vlrs.append(new_vlr)
             self.extra_dimensions = [new_dimension]
-            
+
             new_pt_fmt = laspy.util.Format(self.point_format.fmt, extradims = self.extra_dimensions)
             self.point_format = new_pt_fmt
             self.set_header_property("data_record_length", self.point_format.rec_len)
@@ -1153,8 +1193,8 @@ class Writer(FileManager):
 
         if not self.has_point_records:
             self.has_point_records = True
-            self.set_header_property("point_records_count", len(new_dim)) 
-            self.pad_file_for_point_recs(len(new_dim)) 
+            self.set_header_property("point_records_count", len(new_dim))
+            self.pad_file_for_point_recs(len(new_dim))
 
 
         ptrecs = self.get_pointrecordscount()
@@ -1164,9 +1204,9 @@ class Writer(FileManager):
             spec = self.point_format.lookup[name]
             return(self._set_dimension(spec, new_dim))
         except KeyError:
-            raise laspy.util.LaspyException("Dimension: " + str(name) + 
+            raise laspy.util.LaspyException("Dimension: " + str(name) +
                             "not found.")
- 
+
     def _set_dimension(self, spec, value):
         self.data_provider._pmap["point"][spec.name] = value
         return
@@ -1183,18 +1223,18 @@ class Writer(FileManager):
             i += 1
 
         #idx = xrange(self.calc_point_recs)
-        #starts = (self.point_refs[i] + offs for i in idx) 
+        #starts = (self.point_refs[i] + offs for i in idx)
         #def f_set(x):
         #    i = starts.next()
         #    #self.seek(i, rel = False)
         #    #self.data_provider._mmap.write(pack(fmt, new_dim[x]))
         #    self.data_provider._mmap[i:i + length] = pack(fmt,new_dim[x])
-        #map(f_set, idx) 
-        
+        #map(f_set, idx)
+
         # Is this desireable
         #self.data_provider._mmap.flush()    def write_bytes(self, idx, bytes):
         return True
-    
+
     def set_points(self, points):
         '''Set the point data for the file, using either a list of laspy.util.Point
         instances, or a numpy array of point data (as recieved from get_points).'''
@@ -1212,10 +1252,10 @@ class Writer(FileManager):
              self.data_provider._pmap[:] = points[:]
              #self.data_provider.point_map()
         #single_fmt = self.point_format.pt_fmt_long[1:]
-        #big_fmt_string = "".join(["<", single_fmt*self.header.point_records_count]) 
+        #big_fmt_string = "".join(["<", single_fmt*self.header.point_records_count])
         #out = []
         #(point.unpacked for point in points)
-        #for i in points: 
+        #for i in points:
         #    out.extend(i.unpacked)
         #bytestr = pack(big_fmt_string, *out)
         #self.data_provider._mmap[self.header.data_offset:self.data_provider._mmap.size()] = bytestr
@@ -1227,12 +1267,12 @@ class Writer(FileManager):
         '''Set a point dimension of appropriate name to new_dim'''
         ptrecs = self.get_pointrecordscount()
         if len(new_raw_points) != ptrecs:
-            raise laspy.util.LaspyException("Error, new dimension length (%s) does not match"%str(len(new_raw_points)) + " the number of points (%s)" % str(ptrecs)) 
+            raise laspy.util.LaspyException("Error, new dimension length (%s) does not match"%str(len(new_raw_points)) + " the number of points (%s)" % str(ptrecs))
         if type(self.point_refs) == bool:
             self.build_point_refs()
         idx = (xrange(len(self.point_refs)))
         def f(x):
-            self.data_provider._mmap[self.point_refs[x]:self.point_refs[x] 
+            self.data_provider._mmap[self.point_refs[x]:self.point_refs[x]
                     + self.header.data_record_length] = new_raw_points[x]
         map(f, idx)
         self.data_provider.point_map()
@@ -1243,13 +1283,13 @@ class Writer(FileManager):
         self.data_provider._mmap[rec_offs+spec.offs:rec_offs+spec.offs +
                   spec.num*spec.length] = val
         return
-    
+
     def _set_datum(self, rec_offs, dim, val):
-        '''Set a non dimension field as with _set_raw_datum, but supply a formatted value''' 
+        '''Set a non dimension field as with _set_raw_datum, but supply a formatted value'''
 
         if dim.num == 1:
             lb = rec_offs + dim.offs
-            ub = lb + dim.length 
+            ub = lb + dim.length
             try:
                 self.data_provider._mmap[lb:ub] = struct.pack(dim.fmt, val)
             except:
@@ -1263,16 +1303,16 @@ class Writer(FileManager):
             dimlen = 1
 
         if dim.num != dimlen:
-            raise(laspy.util.LaspyException("Fields must be replaced with data of the same length. " + 
-                                str(dim.name) +" should be length " + 
+            raise(laspy.util.LaspyException("Fields must be replaced with data of the same length. " +
+                                str(dim.name) +" should be length " +
                                 str(dim.num) +", received " + str(dimlen) ))
         def f(x):
             try:
                 outbyte = struct.pack(dim.fmt, val[x])
             except:
                 outbyte = struct.pack(dim.fmt, int(val[x]))
-            self.data_provider._mmap[(x*dim.length + rec_offs + 
-                    dim.offs):((x+1)*dim.length + rec_offs 
+            self.data_provider._mmap[(x*dim.length + rec_offs +
+                    dim.offs):((x+1)*dim.length + rec_offs
                     + dim.offs)]=outbyte
         map(f, xrange(dim.num))
         return
@@ -1282,7 +1322,7 @@ class Writer(FileManager):
         try:
             spec = self.header_format.lookup[name]
         except(KeyError):
-            raise(laspy.util.LaspyException("Header Dimension: " + 
+            raise(laspy.util.LaspyException("Header Dimension: " +
                   str(name) + " not found."))
         self._set_raw_datum(0, spec, value)
 
@@ -1294,17 +1334,17 @@ class Writer(FileManager):
             raise laspy.util.LaspyException("Header Dimension: " + str(name) + " not found.")
         if not dim.overwritable:
             raise(laspy.util.LaspyException("Field " + dim.name + " is not overwritable."))
-        
+
         self._set_datum(0, dim, value)
         self.header_changes.add(name)
         return
 
     def set_header(self, header):
         raise NotImplementedError
-    
+
     def set_input_srs(self, srs):
         raise NotImplementedError
-    
+
     def set_output_srs(self, srs):
         raise NotImplementedError
 
@@ -1337,19 +1377,19 @@ class Writer(FileManager):
         '''Wrapper for set_dimension("intensity", new_dimension)'''
         self.set_dimension("intensity", intensity)
         return
-    
+
     def set_flag_byte(self, byte):
         '''Wrapper for set_dimension("flag_byte", new_dimension)'''
         self.set_dimension("flag_byte", byte)
         return
-    
+
     # Utility Functions, refactor
-    
+
     def bitpack(self, arrs, indices):
         '''Pack an array of integers into a byte based on idx
         for example bitpack((arr1, arr2), (0,3), (3,8)) packs the integers
         arr1 and arr2 into a byte, using the first three bits
-        of arr1, and the last five bits of arr2. 
+        of arr1, and the last five bits of arr2.
         '''
         def keep_bits(arr, low, high):
             """ Keep only the bits on the interval [low, high) """
@@ -1361,13 +1401,13 @@ class Writer(FileManager):
         packed = np.zeros_like(arrs[0])
         for arr, (low, high) in zip(arrs, indices):
             if low > first_bit_idx:
-                packed += np.right_shift(keep_bits(arr, low, high), 
+                packed += np.right_shift(keep_bits(arr, low, high),
                                          low - first_bit_idx)
             else:
-                packed += np.left_shift(keep_bits(arr, low, high), 
+                packed += np.left_shift(keep_bits(arr, low, high),
                                         first_bit_idx - low)
 
-            # First bit index should never be > 8 if we are 
+            # First bit index should never be > 8 if we are
             # packing values to a byte
             first_bit_idx += high - low
 
@@ -1382,7 +1422,7 @@ class Writer(FileManager):
 
 
     def set_return_num(self, num):
-        '''Set the binary field return_num in the flag_byte''' 
+        '''Set the binary field return_num in the flag_byte'''
         self._header_current = False
         if self.header.data_format_id in (0,1,2,3,4,5):
             flag_byte = self.get_flag_byte()
@@ -1411,26 +1451,26 @@ class Writer(FileManager):
             self.set_dimension("flag_byte", outByte)
         return
 
-    def set_scanner_channel(self, value): 
+    def set_scanner_channel(self, value):
         if not self.header.data_format_id in (6,7,8,9,10):
             raise laspy.util.LaspyException("Scanner Channel not present for point format: " + str(self.header.data_format_id))
         raw_dim = self.get_raw_classification_flags()
         self.raise_if_overflow(value, 2)
         outByte = self.bitpack((raw_dim, value, raw_dim), ((0,4), (0,2), (6,8)))
-        self.set_raw_classification_flags(outByte) 
+        self.set_raw_classification_flags(outByte)
 
-    def set_scan_dir_flag(self, flag): 
+    def set_scan_dir_flag(self, flag):
         '''Set the binary field scan_dir_flag in the flag_byte'''
         if self.header.data_format_id in (0,1,2,3,4,5):
             flag_byte = self.get_flag_byte()
             self.raise_if_overflow(flag, 1)
-            outByte = self.bitpack((flag_byte,flag,flag_byte), 
+            outByte = self.bitpack((flag_byte,flag,flag_byte),
                 ((0,6),(0,1), (7,8)))
             self.set_dimension("flag_byte", outByte)
         elif self.header.data_format_id in (6,7,8,9,10):
             flag_byte = self.get_raw_classification_flags()
             self.raise_if_overflow(flag, 1)
-            outByte = self.bitpack((flag_byte,flag,flag_byte), 
+            outByte = self.bitpack((flag_byte,flag,flag_byte),
                 ((0,6),(0,1), (7,8)))
             self.set_dimension("classification_flags", outByte)
         return
@@ -1454,8 +1494,8 @@ class Writer(FileManager):
 
     def set_raw_classification_flags(self, value):
         self.set_dimension("classification_flags",value)
-    
-    def set_classification_flags(self, value): 
+
+    def set_classification_flags(self, value):
         if not self.header.data_format_id in (6,7,8,9,10):
             self.set_classification(value)
             return
@@ -1466,7 +1506,7 @@ class Writer(FileManager):
         return
 
     def set_raw_classification(self, classification):
-        '''Set the entire classification byte at once. This is faster than setting the binary fields individually, 
+        '''Set the entire classification byte at once. This is faster than setting the binary fields individually,
         but care must be taken that the values mean what you think they do. '''
         self.set_dimension("raw_classification", classification)
 
@@ -1488,7 +1528,7 @@ class Writer(FileManager):
         if self.header.data_format_id in (6,7,8,9,10):
             class_byte = self.get_raw_classification_flags()
             self.raise_if_overflow(synthetic, 1)
-            out_byte = self.bitpack((synthetic, class_byte), 
+            out_byte = self.bitpack((synthetic, class_byte),
                                     ((0,1), (1,8)))
             self.set_raw_classification_flags(out_byte)
         else:
@@ -1509,11 +1549,11 @@ class Writer(FileManager):
         else:
             class_byte = self.get_raw_classification()
             self.raise_if_overflow(pt, 1)
-            out_byte = self.bitpack((class_byte, pt, class_byte), 
+            out_byte = self.bitpack((class_byte, pt, class_byte),
                                 ((0,6),(0,1),(7,8)))
             self.set_dimension("raw_classification", out_byte)
         return
- 
+
     def set_withheld(self, withheld):
         '''Set the binary field withheld inside the raw classification byte'''
         if self.header.data_format_id in (6,7,8,9,10):
@@ -1550,24 +1590,24 @@ class Writer(FileManager):
         '''Wrapper for set_dimension("user_data")'''
         self.set_dimension("user_data", data)
         return
-    
+
     def set_pt_src_id(self, data):
         '''Wrapper for set_dimension("pt_src_id")'''
         self.set_dimension("pt_src_id", data)
         return
-    
+
     def set_gps_time(self, data):
         '''Wrapper for set_dimension("gps_time")'''
         self.set_dimension("gps_time", data)
-    
+
     def set_red(self, red):
         '''Wrapper for set_dimension("red")'''
         self.set_dimension("red", red)
 
     def set_green(self, green):
         '''Wrapper for set_dimension("green")'''
-        self.set_dimension("green", green) 
-    
+        self.set_dimension("green", green)
+
     def set_blue(self, blue):
         '''Wrapper for set_dimension("blue")'''
         self.set_dimension("blue", blue)
@@ -1576,7 +1616,7 @@ class Writer(FileManager):
         self.get_dimension("nir", value)
 
     def set_wave_packet_desc_index(self, idx):
-        '''Wrapper for set_dimension("wave_packet_desc_index") This is not currently functional, 
+        '''Wrapper for set_dimension("wave_packet_desc_index") This is not currently functional,
         since addition of waveform data broke the numpy point map.'''
         self.set_dimension("wave_packet_desc_index", idx)
 
@@ -1584,17 +1624,17 @@ class Writer(FileManager):
         '''Wrapper for set_dimension("byte_offset_to_waveform_data"), not currently functional,
         because addition of waveform data broke the numpy point map.'''
         self.set_dimension("byte_offset_to_waveform_data", idx)
-    
+
     def set_waveform_packet_size(self, size):
         '''Wrapper for set_dimension("waveform_packet_size"), not currently functional, because
         addition of waveform data broke the numpy point map.'''
         self.set_dimension("waveform_packet_size", size)
-    
+
     def set_return_point_waveform_loc(self, loc):
         '''Wrapper for set_dimension("return_point_waveform_loc"), not currently functional,
         because addition of waveform data broke the numpy point map.'''
         self.set_dimension("return_point_waveform_loc", loc)
-    
+
     def set_x_t(self, x):
         '''Wrapper for set_dimension("x_t")'''
         self.set_dimension("x_t", x)
@@ -1602,7 +1642,7 @@ class Writer(FileManager):
     def set_y_t(self, y):
         '''Wrapper for set_dimension("y_t")'''
         self.set_dimension("y_t", y)
-    
+
     def set_z_t(self, z):
         '''Wrapper for set_dimension("z_t")'''
         self.set_dimension("z_t", z)
@@ -1612,7 +1652,7 @@ class Writer(FileManager):
         if "extra_bytes" in self.point_format.lookup.keys():
             self.set_dimension("extra_bytes", extra_bytes)
         elif self.extra_dimensions != []:
-            newmap = self.data_provider.get_point_map(self.naive_point_format) 
+            newmap = self.data_provider.get_point_map(self.naive_point_format)
             newmap["point"]["extra_bytes"] = extra_bytes
         else:
             raise laspy.util.LaspyException("Extra bytes not present in point format. Try creating a new file with an extended point record length.")

--- a/laspy/header.py
+++ b/laspy/header.py
@@ -15,7 +15,7 @@ def leap_year(year):
     return True
 
 ## NOTE: set_attr methods are currently not implemented. These methods need
-## to update the file using reader/mmap. 
+## to update the file using reader/mmap.
 class LaspyHeaderException(Exception):
     pass
 
@@ -23,7 +23,7 @@ class LaspyHeaderException(Exception):
 class ParseableVLR():
     def parse_data(self):
         '''Attempt to read VLR or EVLR body into the parsed_body attribute.'''
- 
+
         if "LASF_Projection" in self.user_id and self.record_id == 2111:
             # OGC Math Transform WKT Record
             self.body_fmt = util.Format(None)
@@ -40,8 +40,8 @@ class ParseableVLR():
             self.body_fmt.add("wKeyDirectoryVersion", "ctypes.c_ushort", 1)
             self.body_fmt.add("wKeyRevision", "ctypes.c_ushort", 1)
             self.body_fmt.add("wMinorRevision", "ctypes.c_ushort", 1)
-            self.body_fmt.add("wNumberOfKeys", "ctypes.c_ushort", 1)   
-            # Rest is made up of arrays of 4 unsigned shorts. 
+            self.body_fmt.add("wNumberOfKeys", "ctypes.c_ushort", 1)
+            # Rest is made up of arrays of 4 unsigned shorts.
             bytes_left = (self.rec_len_after_header - 4*2)
             if bytes_left % (4*2) != 0:
                 print("WARNING: Invalid body length for GeoKeyDictionaryTag, Not parsing.")
@@ -67,7 +67,7 @@ class ParseableVLR():
             self.body_fmt = util.Format(None)
             self.body_fmt.add("GeoASCIIParamsTag", "ctypes.c_char", self.rec_len_after_header)
 
-        elif "LASF_Spec" in self.user_id and self.record_id == 0:            
+        elif "LASF_Spec" in self.user_id and self.record_id == 0:
             # Classification Lookup
             self.body_fmt = util.Format(None)
             if self.rec_len_after_header % 16 != 0:
@@ -77,7 +77,7 @@ class ParseableVLR():
                 self.body_fmt.add("ClassNumber_%i", "ctypes.c_ubyte", 1)
                 self.body_fmt.add("Description_%i", "ctypes.c_char", 15)
 
-        elif "LASF_Spec" in self.user_id and self.record_id == 1:            
+        elif "LASF_Spec" in self.user_id and self.record_id == 1:
             # Header Flight line lookup
             self.body_fmt = util.Format(None)
             if self.rec_len_after_header % 257 != 0:
@@ -87,12 +87,12 @@ class ParseableVLR():
                 self.body_fmt.add("FileMarkerNumber_%i", "ctypes.c_ubyte", 1)
                 self.body_fmt.add("Filename_%i", "ctypes.c_char", 256)
 
-        elif "LASF_Spec" in self.user_id and self.record_id == 3:            
+        elif "LASF_Spec" in self.user_id and self.record_id == 3:
             #Text Area Description
             self.body_fmt = util.Format(None)
             self.body_fmt.add("text_area_description", "ctypes.c_char", self.rec_len_after_header)
 
-        elif "LASF_Spec" in self.user_id and self.record_id == 4:            
+        elif "LASF_Spec" in self.user_id and self.record_id == 4:
             # Extra Bytes, currently handled by VLR constructor
             pass
 
@@ -110,14 +110,14 @@ class ParseableVLR():
             self.parsed_body = np.array(struct.unpack(self.body_fmt.pt_fmt_long, self.VLR_body))
         else:
             self.parsed_body = None
-    
+
     def pack_data(self):
         '''Pack data from parsed_body into VLR_body.'''
         if self.body_fmt == None:
             raise util.LaspyException("Not a known VLR/EVLR type, can't pack parsed_body")
         try:
             packed = struct.pack(self.body_fmt.pt_fmt_long, *self.parsed_body)
-        except Exception, error:    
+        except Exception, error:
             print("Error packing VLR data, using current raw vlr body.")
             print(error)
             packed = self.VLR_body
@@ -137,11 +137,11 @@ class ExtraBytesStruct(object):
     '''This class provides a frontend for the Extra Bytes Struct as defined
     in the LAS 1.4 specification. All Arguments are assumed to be default values
     unless specified - the two really key ones are name and data_type. This structure
-    lives in the VLR_body property of a laspy.header.VLR instance, and multiple 
+    lives in the VLR_body property of a laspy.header.VLR instance, and multiple
     ExtraByteStruct records can be present together. Each ExtraBytesStruct instance
-    describes an additional dimension present at the end of each point record. ''' 
-    def __init__(self, data_type = 0, options = 0, name = "\x00"*32, 
-                 unused = [0]*4, no_data = [0.0]*3, min = [0.0]*3, 
+    describes an additional dimension present at the end of each point record. '''
+    def __init__(self, data_type = 0, options = 0, name = "\x00"*32,
+                 unused = [0]*4, no_data = [0.0]*3, min = [0.0]*3,
                  max = [0.0]*3, scale = [1.0]*3, offset = [0.0]*3,
                  description = "\x00"*32):
         self.fmt = util.Format("extra_bytes_struct")
@@ -150,7 +150,7 @@ class ExtraBytesStruct(object):
         self.vlr_parent = False
         self.names = [x.name for x in self.fmt.specs]
 
-        self.data = "\x00"*192 
+        self.data = "\x00"*192
         self.set_property("data_type" , data_type)
         self.set_property("options" , options)
         self.set_property("name" , name + "\x00"*(32-len(description)))
@@ -167,13 +167,13 @@ class ExtraBytesStruct(object):
         self.data = vlr_parent.VLR_body[192*body_offset:192*(body_offset + 1)]
         self.vlr_parent = vlr_parent
         self.body_offset = body_offset
-    
+
     def assertWriteable(self):
         if self.writeable or self.vlr_parent.reader == False:
             return
         raise util.LaspyException("""To modify VLRs and EVLRs, you must create new
-                            variable length records, and then replace them via 
-                            file.header.vlrs or file.header.evlrs. To do otherwise 
+                            variable length records, and then replace them via
+                            file.header.vlrs or file.header.evlrs. To do otherwise
                             would cause data concurrency issues.""")
 
     def get_property_idx(self, name):
@@ -186,12 +186,12 @@ class ExtraBytesStruct(object):
 
     def get_property(self, name):
         fmt = self.fmt.specs[self.get_property_idx(name)]
-        unpacked = struct.unpack(fmt.full_fmt, 
+        unpacked = struct.unpack(fmt.full_fmt,
                    self.data[fmt.offs:(fmt.offs + fmt.length*fmt.num)])
         if len(unpacked) == 1:
             return(unpacked[0])
         return(unpacked)
-    
+
     def to_byte_string(self):
         '''Return the struct as a string of raw bytes. This is useful for providing
         the struct to a VLR instance via VLR_body.'''
@@ -202,14 +202,14 @@ class ExtraBytesStruct(object):
         fmt = self.fmt.specs[self.get_property_idx(name)]
         if isinstance(value, int) or isinstance(value, str):
             packed = struct.pack(fmt.full_fmt, value)
-            self.data = self.data[0:fmt.offs] + packed + self.data[fmt.offs + len(packed):len(self.data)]  
-        else: 
+            self.data = self.data[0:fmt.offs] + packed + self.data[fmt.offs + len(packed):len(self.data)]
+        else:
             packed = struct.pack(fmt.full_fmt, *value)
-            self.data = self.data[0:fmt.offs] + packed + self.data[fmt.offs + len(packed):len(self.data)]  
+            self.data = self.data[0:fmt.offs] + packed + self.data[fmt.offs + len(packed):len(self.data)]
 
         if self.vlr_parent != False:
             idx_start = 192*self.body_offset
-            idx_stop = 192*(self.body_offset + 1) 
+            idx_stop = 192*(self.body_offset + 1)
             d1 = self.vlr_parent.VLR_body[0:idx_start]
             d2 = self.vlr_parent.VLR_body[idx_stop:len(self.vlr_parent.VLR_body)]
             self.vlr_parent.VLR_body = (d1 + self.data + d2)
@@ -257,7 +257,7 @@ class ExtraBytesStruct(object):
         self.set_property("max", value)
     max = property(get_max, set_max, None, None)
 
-    def get_scale(self): 
+    def get_scale(self):
         return(self.get_property("scale"))
     def set_scale(self, value):
         self.set_property("scale", value)
@@ -275,7 +275,7 @@ class ExtraBytesStruct(object):
         self.set_property(self, "description")
     description = property(get_description, set_description, None, None)
 
-        
+
 class EVLR(ParseableVLR):
     ''' An extended VLR as defined in LAS specification 1.4'''
     def __init__(self, user_id, record_id, VLR_body, **kwargs):
@@ -286,8 +286,8 @@ class EVLR(ParseableVLR):
         self.VLR_body = VLR_body
         self.body_fmt = None
 
-        try: 
-            self.rec_len_after_header = len(self.VLR_body) 
+        try:
+            self.rec_len_after_header = len(self.VLR_body)
         except(TypeError):
             self.rec_len_after_header = 0
         if "description" in kwargs:
@@ -297,7 +297,7 @@ class EVLR(ParseableVLR):
         if "reserved" in kwargs:
             self.reserved = kwargs["reserved"]
         else:
-            self.reserved = 0 
+            self.reserved = 0
         self.fmt = util.Format("EVLR")
         self.isEVLR = True
         self.type = 0
@@ -349,29 +349,29 @@ class EVLR(ParseableVLR):
         '''Return the size of the evlr object in bytes'''
         return self.rec_len_after_header + 60
 
-    def pack(self, name, val): 
+    def pack(self, name, val):
         '''Pack an EVLR field into bytes.'''
         spec = self.fmt.lookup[name]
         if spec.num == 1:
             return(struct.pack(spec.full_fmt, val))
         return(struct.pack(spec.fmt[0]+spec.fmt[1]*len(val), *val))
-    
+
     def to_byte_string(self):
         '''Pack the entire EVLR into a byte string.'''
         if type(self.parsed_body) != type(None):
             self.pack_data()
-        out = (self.pack("reserved", self.reserved) + 
-               self.pack("user_id", self.user_id) + 
-               self.pack("record_id", self.record_id) + 
-               self.pack("rec_len_after_header", self.rec_len_after_header) + 
+        out = (self.pack("reserved", self.reserved) +
+               self.pack("user_id", self.user_id) +
+               self.pack("record_id", self.record_id) +
+               self.pack("rec_len_after_header", self.rec_len_after_header) +
                self.pack("description", self.description) +
                self.VLR_body)
         diff = (self.rec_len_after_header - len(self.VLR_body))
         if diff > 0:
             out += "\x00"*diff
         elif diff < 0:
-            raise util.LaspyException("Invalid Data in EVLR: too long for specified rec_len." + 
-                                " rec_len_after_header = " + str(self.rec_len_after_header) + 
+            raise util.LaspyException("Invalid Data in EVLR: too long for specified rec_len." +
+                                " rec_len_after_header = " + str(self.rec_len_after_header) +
                                 " actual length = " + str(len(self.VLR_body)))
         return(out)
 
@@ -399,7 +399,7 @@ class VLR(ParseableVLR):
         if "reserved" in kwargs:
             self.reserved = kwargs["reserved"]
         else:
-            self.reserved = 0 
+            self.reserved = 0
         self.reserved = 0
         self.isVLR = True
         self.fmt = util.Format("VLR")
@@ -446,9 +446,9 @@ class VLR(ParseableVLR):
             recs = self.rec_len_after_header / 192
             for i in xrange(recs):
                 new_rec = ExtraBytesStruct()
-                new_rec.build_from_vlr(self, i) 
+                new_rec.build_from_vlr(self, i)
                 self.add_extra_dim(new_rec)
-        
+
     def add_extra_dim(self, new_rec):
         new_name = new_rec.name.replace("\x00", "").replace(" ", "_").lower()
         self.__dict__[new_name] = new_rec
@@ -459,36 +459,36 @@ class VLR(ParseableVLR):
         '''Return the size of the vlr object in bytes'''
         return self.rec_len_after_header + 54
 
-    def pack(self, name, val): 
+    def pack(self, name, val):
         '''Pack a VLR field into bytes.'''
         spec = self.fmt.lookup[name]
         if spec.num == 1:
             return(struct.pack(spec.fmt, val))
         return(struct.pack(spec.fmt[0]+spec.fmt[1]*len(val), *val))
-    
+
     def to_byte_string(self):
         '''Pack the entire VLR into a byte string.'''
         if type(self.parsed_body) != type(None):
             self.pack_data()
-        out = (self.pack("reserved", self.reserved) + 
-               self.pack("user_id", self.user_id) + 
-               self.pack("record_id", self.record_id) + 
-               self.pack("rec_len_after_header", self.rec_len_after_header) + 
+        out = (self.pack("reserved", self.reserved) +
+               self.pack("user_id", self.user_id) +
+               self.pack("record_id", self.record_id) +
+               self.pack("rec_len_after_header", self.rec_len_after_header) +
                self.pack("description", self.description) +
                self.VLR_body)
         diff = (self.rec_len_after_header - len(self.VLR_body))
         if diff > 0:
             out += "\x00"*diff
         elif diff < 0:
-            raise util.LaspyException("Invalid Data in VLR: too long for specified rec_len." + 
-                                " rec_len_after_header = " + str(self.rec_len_after_header) + 
+            raise util.LaspyException("Invalid Data in VLR: too long for specified rec_len." +
+                                " rec_len_after_header = " + str(self.rec_len_after_header) +
                                 " actual length = " + str(len(self.VLR_body)))
         return(out)
 
 class Header(object):
-    '''The low level header class. Header is built from a laspy.util.Format 
+    '''The low level header class. Header is built from a laspy.util.Format
     instance, or assumes a default file format of 1.2. Header is usually interacted with via
-    the HeaderManager class, an instance of which readers, writers, and file 
+    the HeaderManager class, an instance of which readers, writers, and file
     objects retain a reference of.'''
     def __init__(self, file_version = 1.2, point_format = 0, **kwargs):
         # At least generate a default las format
@@ -514,9 +514,9 @@ class Header(object):
             if not item.name in self.__dict__.keys():
                 self.__dict__[item.name] = item.default
 
-        # Clear no longer available fields. 
+        # Clear no longer available fields.
         for item in self._format.specs:
-            if not item.name in new_format.lookup.keys(): 
+            if not item.name in new_format.lookup.keys():
                 self.__dict__[item.name] = None
         if str(file_version) == "1.4":
             self.point_return_count.extend([0]*10)
@@ -533,14 +533,14 @@ class Header(object):
 
 
 class HeaderManager(object):
-    '''HeaderManager provides the public API for interacting with header objects. 
-    It requires a Header instance and a reader/writer instance. 
+    '''HeaderManager provides the public API for interacting with header objects.
+    It requires a Header instance and a reader/writer instance.
     HeaderManager instances are referred to in reader/writer/file object code as header.'''
     def __init__(self, header, reader):
         '''Build the header manager object'''
         self.reader = reader
         self.writer = reader
-        self._header = header 
+        self._header = header
         self.file_mode = reader.mode
         if self.file_mode == "w":
             self.allow_all_overwritables()
@@ -549,7 +549,7 @@ class HeaderManager(object):
         return(self.__copy__())
 
     def __copy__(self):
-        '''Populate and return a Header instance with data matching the file to which 
+        '''Populate and return a Header instance with data matching the file to which
         the HeaderManager belongs. This is useful for creating new files with modified
         formats.'''
         self.pull()
@@ -582,7 +582,7 @@ class HeaderManager(object):
         if pack:
             return("".join(out))
         return(out)
-        
+
     def get_filesignature(self):
         '''Returns the file signature for the file. It should always be
         LASF'''
@@ -627,7 +627,7 @@ class HeaderManager(object):
     encoding = global_encoding
 
 
-    doc = '''Indicates the meaning of GPS Time in the point records. 
+    doc = '''Indicates the meaning of GPS Time in the point records.
              If gps_time_type is zero, then GPS Time is GPS Week Time. Otherwise
              it refers to sattelite GPS time.'''
     def get_gps_time_type(self):
@@ -635,8 +635,8 @@ class HeaderManager(object):
         return(self.reader.binary_str(raw_encoding, 16)[0])
     def set_gps_time_type(self, value):
         self.assertWriteMode()
-        raw_encoding = self.reader.binary_str(self.get_global_encoding(),16)       
-        self.set_global_encoding(self.reader.packed_str(str(value) 
+        raw_encoding = self.reader.binary_str(self.get_global_encoding(),16)
+        self.set_global_encoding(self.reader.packed_str(str(value)
                                 + raw_encoding[1:]))
         return
 
@@ -652,7 +652,7 @@ class HeaderManager(object):
         self.set_global_encoding(self.reader.packed_str(raw_encoding[0] + str(value) + raw_encoding[2:]))
         return
 
-    waveform_data_packets_internal = property(get_waveform_data_packets_internal, 
+    waveform_data_packets_internal = property(get_waveform_data_packets_internal,
                                               set_waveform_data_packets_internal,
                                               None, None)
 
@@ -667,7 +667,7 @@ class HeaderManager(object):
         return
 
     waveform_data_packets_external = property(get_waveform_data_packets_external,
-                                              set_waveform_data_packets_external, 
+                                              set_waveform_data_packets_external,
                                               None, None)
     def get_synthetic_return_num(self):
         raw_encoding = self.get_global_encoding()
@@ -679,7 +679,7 @@ class HeaderManager(object):
         self.set_global_encoding(self.reader.packed_str(raw_encoding[0:3] + str(value) + raw_encoding[4:]))
         return
 
-    synthetic_return_num = property(get_synthetic_return_num, set_synthetic_return_num, 
+    synthetic_return_num = property(get_synthetic_return_num, set_synthetic_return_num,
                                     None, None)
 
     def get_wkt(self):
@@ -699,13 +699,13 @@ class HeaderManager(object):
 
     wkt = property(get_wkt, set_wkt, None, None)
 
-    def get_projectid(self): 
+    def get_projectid(self):
         p1 = self.reader.get_raw_header_property("proj_id_1")
         p2 = self.reader.get_raw_header_property("proj_id_2")
         p3 = self.reader.get_raw_header_property("proj_id_3")
-        p4 = self.reader.get_raw_header_property("proj_id_4") 
+        p4 = self.reader.get_raw_header_property("proj_id_4")
         return(uuid.UUID(bytes =p1+p2+p3+p4))
- 
+
     doc = '''ProjectID for the file.  \
         laspy does not currently support setting this value from Python, as
         it is the same as :obj:`laspy.header.Header.guid`. Use that to
@@ -726,7 +726,7 @@ class HeaderManager(object):
 
     def get_guid(self):
         '''Returns the GUID for the file as a :obj:`uuid.UUID` object.'''
-        return self.get_projectid() 
+        return self.get_projectid()
 
     def set_guid(self, value):
         raw_bytes = uuid.UUID.get_bytes_le(value)
@@ -742,14 +742,14 @@ class HeaderManager(object):
         '''Sets the GUID for the file. It must be a :class:`uuid.UUID`
         instance'''
         return
-    doc = '''The GUID/:obj:`laspy.header.Header.project_id` for the file. 
+    doc = '''The GUID/:obj:`laspy.header.Header.project_id` for the file.
     Accepts a :obj:`uuid.UUID` object.'''
     guid = property(get_guid, set_guid, None, doc)
 
     def get_majorversion(self):
         '''Returns the major version for the file. Expect this value to always
         be 1'''
-        return self.reader.get_header_property("version_major") 
+        return self.reader.get_header_property("version_major")
 
     def set_majorversion(self, value):
         '''Sets the major version for the file. Only the value 1 is accepted
@@ -765,14 +765,14 @@ class HeaderManager(object):
     def get_minorversion(self):
         '''Returns the minor version of the file. Expect this value to always
         be 0, 1, or 2'''
-        return self.reader.get_header_property("version_minor") 
+        return self.reader.get_header_property("version_minor")
 
     def set_minorversion(self, value):
         '''Sets the minor version of the file. The value should be 0 for 1.0
         LAS files, 1 for 1.1 LAS files ...'''
         self.assertWriteMode()
         self.writer.set_header_property("version_minor",value)
-        return 
+        return
     doc = '''The minor version for the file.'''
     minor_version = property(get_minorversion, set_minorversion, None, doc)
     version_minor = minor_version
@@ -785,8 +785,8 @@ class HeaderManager(object):
         self.writer.set_header_property("version_minor", int(minor))
 
     def get_version(self):
-        major = self.reader.get_header_property("version_major") 
-        minor = self.reader.get_header_property("version_minor") 
+        major = self.reader.get_header_property("version_major")
+        minor = self.reader.get_header_property("version_minor")
         return '%d.%d' % (major, minor)
     doc = '''The version as a dotted string for the file (ie, '1.0', '1.1',
     etc)'''
@@ -814,7 +814,7 @@ class HeaderManager(object):
         '''
         self.assertWriteMode()
         return(self.writer.set_header_property("software_id", value))
-    doc = '''The software ID for the file''' 
+    doc = '''The software ID for the file'''
     software_id = property(get_softwareid, set_softwareid, None, doc)
 
     def get_date(self):
@@ -824,7 +824,7 @@ class HeaderManager(object):
         Note that dates in LAS headers are not transitive because the header
         only stores the year and the day number.
         '''
-        day = self.reader.get_header_property("created_day") 
+        day = self.reader.get_header_property("created_day")
         year = self.reader.get_header_property("created_year")
 
         if year == 0 and day == 0:
@@ -866,7 +866,7 @@ class HeaderManager(object):
     def set_headersize(self, val):
         self.assertWriteMode()
         self.writer.set_header_property("header size", val)
-    doc = '''The header size for the file. You probably shouldn't touch this.''' 
+    doc = '''The header size for the file. You probably shouldn't touch this.'''
     header_size = property(get_headersize, set_headersize, None, doc)
     header_length = header_size
 
@@ -883,15 +883,15 @@ class HeaderManager(object):
         '''
         self.assertWriteMode()
         ## writer.set_padding handles data offset update.
-        self.writer.set_padding(value-self.writer.vlr_stop) 
+        self.writer.set_padding(value-self.writer.vlr_stop)
         return
     doc = '''The offset to the point data in the file. This can not be smaller then the header size + VLR length. '''
     data_offset = property(get_dataoffset, set_dataoffset, None, doc)
 
     def get_padding(self):
-        '''Returns number of bytes between the end of the VLRs and the 
+        '''Returns number of bytes between the end of the VLRs and the
            beginning of the point data.'''
-        return self.reader.get_padding() 
+        return self.reader.get_padding()
 
     def set_padding(self, value):
         '''Sets the header's padding.
@@ -899,45 +899,53 @@ class HeaderManager(object):
         self.assertWriteMode()
         self.writer.set_padding(value)
         return
-    doc = '''The number of bytes between the end of the VLRs and the 
+    doc = '''The number of bytes between the end of the VLRs and the
     beginning of the point data.
     '''
     padding = property(get_padding, set_padding, None, doc)
 
     def get_recordscount(self):
         return self.reader.get_pointrecordscount()
-    doc = '''Returns the number of user-defined header records in the header. 
+    doc = '''Returns the number of user-defined header records in the header.
     '''
-    records_count = property(get_recordscount, None, None, doc) 
+    records_count = property(get_recordscount, None, None, doc)
 
     def get_dataformatid(self):
         '''The point format value as an integer
         '''
-        return self.reader.get_header_property("data_format_id") 
+        length = self.reader.get_header_property("data_format_id")
+        fmt = int(length)
+        compression_bit_7 = (fmt & 0x80) >> 7
+        compression_bit_6 = (fmt & 0x40) >> 6
+        if (not compression_bit_6 and compression_bit_7):
+            fmt &= 0x3f;
+        fmt = str(fmt)
+        return length
 
     def set_dataformatid(self, value):
         '''Set the data format ID. This is only available for files in write mode which have not yet been given points.'''
         if value not in range(6):
             raise LaspyHeaderException("Format ID must be 3, 2, 1, or 0")
         if not self.file_mode in ("w", "w+"):
-            raise LaspyHeaderException("Point Format ID can only be set for " + 
+            raise LaspyHeaderException("Point Format ID can only be set for " +
                                         "files in write or append mode.")
         if self.writer.get_pointrecordscount() > 0:
-            raise LaspyHeaderException("Modification of the format of existing " + 
-                                        "points is not currently supported. Make " + 
-                                        "your modifications in numpy and create " + 
+            raise LaspyHeaderException("Modification of the format of existing " +
+                                        "points is not currently supported. Make " +
+                                        "your modifications in numpy and create " +
                                         "a new file.")
         self.writer.set_header_property("data_format_id", value)
-        return 
+        return
     '''The data format ID for the file, determines what point fields are present.'''
     dataformat_id = property(get_dataformatid, set_dataformatid, None, doc)
     data_format_id = dataformat_id
-    
+
 
     def get_datarecordlength(self):
         '''Return the size of each point record'''
         #lenDict = {0:20,1:28,2:26,3:34,4:57,5:63}
-        #return lenDict[self.data_format_id] 
+        #return lenDict[self.data_format_id]
+        length = self.reader.get_header_property('data_record_length')
         return(self.reader.get_header_property("data_record_length"))
 
     doc = '''The length of each point record.'''
@@ -952,11 +960,11 @@ class HeaderManager(object):
 
     doc = '''The header format for the file. Supports .xml and .etree methods.'''
     def set_schema(self, value):
-        if self.file_mode != "w": 
+        if self.file_mode != "w":
             raise NotImplementedError("Converseion between formats is not supported.")
         else:
             self.reader.header_format = value
-    schema = property(get_schema, set_schema, None, doc) 
+    schema = property(get_schema, set_schema, None, doc)
     header_format = schema
     def get_compressed(self):
         return(self.reader.point_format.compressed)
@@ -986,7 +994,7 @@ class HeaderManager(object):
         if not self.file_mode in ("w", "w+","rw"):
             raise LaspyHeaderException("File must be open in a write mode to modify point_records_count.")
         self.writer.set_header_property("point_records_count", value)
-        
+
         '''Sets the number of point records expected in the file.
 
         .. note::
@@ -1000,7 +1008,7 @@ class HeaderManager(object):
     get_count = get_pointrecordscount
     point_records_count = property(get_pointrecordscount,
                                    set_pointrecordscount)
-    count = point_records_count 
+    count = point_records_count
 
     __len__ = get_pointrecordscount
 
@@ -1009,7 +1017,7 @@ class HeaderManager(object):
         0...8
         '''
 
-        return self.reader.get_header_property("point_return_count")   
+        return self.reader.get_header_property("point_return_count")
 
     def set_pointrecordsbyreturncount(self, value):
 
@@ -1019,8 +1027,8 @@ class HeaderManager(object):
         '''
         self.assertWriteMode()
         self.writer.set_header_property("point_return_count", value)
-        return  
-    doc = '''The histogram of point records by return number.''' 
+        return
+    doc = '''The histogram of point records by return number.'''
     point_return_count = property(get_pointrecordsbyreturncount,
                                   set_pointrecordsbyreturncount,
                                   None,
@@ -1039,14 +1047,14 @@ class HeaderManager(object):
         #else:
         #    raise LaspyException("Invalid file version: " + self.version)
         #for i in rawdata:
-        #    histDict[i] += 1        
+        #    histDict[i] += 1
         #raw_hist = histDict.values()
         #if self.data_format_id in (range(6)):
         if self.version != "1.4":
             raw_hist = np.histogram(rawdata, bins = range(1,7))
-            
+
         else:
-            raw_hist = np.histogram(rawdata, bins = range(1,17)) 
+            raw_hist = np.histogram(rawdata, bins = range(1,17))
         #print("Raw Hist: " + str(raw_hist))
         #t = raw_hist[0][4]
         #for ret in [3,2,1,0]:
@@ -1055,9 +1063,9 @@ class HeaderManager(object):
         try:
             self.writer.set_header_property("point_return_count", raw_hist[0])
         except(util.LaspyException):
-            raise util.LaspyException("There was an error updating the num_points_by_return header field. " + 
-        "This is often caused by mal-formed header information. LAS Specifications differ on the length of this field, "+ 
-        "and it is therefore important to set the header version correctly. In the meantime, try File.close(ignore_header_changes = True)" 
+            raise util.LaspyException("There was an error updating the num_points_by_return header field. " +
+        "This is often caused by mal-formed header information. LAS Specifications differ on the length of this field, "+
+        "and it is therefore important to set the header version correctly. In the meantime, try File.close(ignore_header_changes = True)"
         )
     def update_min_max(self, minmax_mode ="scaled"):
         '''Update the min and max X,Y,Z values.'''
@@ -1078,7 +1086,7 @@ class HeaderManager(object):
     def get_scale(self):
         '''Gets the scale factors in [x, y, z] for the point data.
         '''
-        return([self.reader.get_header_property(x) for x in 
+        return([self.reader.get_header_property(x) for x in
                 ["x_scale","y_scale", "z_scale"]])
 
     def set_scale(self, value):
@@ -1089,7 +1097,7 @@ class HeaderManager(object):
         self.writer.set_header_property("y_scale", value[1])
         self.writer.set_header_property("z_scale", value[2])
         return
-    doc = '''The scale factors in [x, y, z] for the point data. 
+    doc = '''The scale factors in [x, y, z] for the point data.
             From the specification:
             The scale factor fields contain a double floating point value that
             is used to scale the corresponding X, Y, and Z long values within
@@ -1109,7 +1117,7 @@ class HeaderManager(object):
     def get_offset(self):
         '''Gets the offset factors in [x, y, z] for the point data.
         '''
-        return([self.reader.get_header_property(x) for x in 
+        return([self.reader.get_header_property(x) for x in
                 ["x_offset", "y_offset", "z_offset"]])
 
     def set_offset(self, value):
@@ -1148,9 +1156,9 @@ class HeaderManager(object):
     def get_min(self):
         '''Gets the minimum values of [x, y, z] for the data.
             For an accuarate result, run header.update_min_max()
-            prior to use. 
+            prior to use.
         '''
-        return([self.reader.get_header_property(x) for x in 
+        return([self.reader.get_header_property(x) for x in
                 ["x_min", "y_min", "z_min"]])
 
     def set_min(self, value):
@@ -1160,10 +1168,10 @@ class HeaderManager(object):
         self.assertWriteMode()
         self.writer.set_header_property("x_min", value[0])
         self.writer.set_header_property("y_min", value[1])
-        self.writer.set_header_property("z_min", value[2]) 
+        self.writer.set_header_property("z_min", value[2])
         return
 
-    doc = '''The minimum values of [x, y, z] for the data in the file. 
+    doc = '''The minimum values of [x, y, z] for the data in the file.
 
         >>> hdr.min
         [0.0, 0.0, 0.0]
@@ -1191,7 +1199,7 @@ class HeaderManager(object):
     doc = '''The maximum values of [x, y, z] for the data in the file.
     '''
     max = property(get_max, set_max, None, doc)
-    
+
 
     def get_start_wavefm_data_record(self):
         if not self.version in ("1.3", "1.4"):
@@ -1229,7 +1237,7 @@ class HeaderManager(object):
             raise util.LaspyException("EVLRs are present explicitly only in version 1.4")
         self.assertWriteMode()
         self.reader.set_header_property("num_evlrs", value)
-    # Encourage users to use len(file.header.vlrs) 
+    # Encourage users to use len(file.header.vlrs)
     #num_evlrs = property(get_num_evlrs, set_num_evlrs, None, None)
 
     def get_legacy_point_records_count(self):
@@ -1241,7 +1249,7 @@ class HeaderManager(object):
         if not self.version == "1.4":
             raise util.LaspyException("Point records count is only denoted as legacy in version 1.4 files.")
         self.reader.set_header_property("legacy_point_records_count", value)
-    
+
     legacy_point_records_count = property(get_legacy_point_records_count, set_legacy_point_records_count, None, None)
 
 
@@ -1260,14 +1268,14 @@ class HeaderManager(object):
     def xml(self):
         '''Return an xml repreentation of header data. (not implemented)'''
         raise NotImplementedError
-    
+
     def etree(self):
         '''Return an etree representation of header data. (not implemented)'''
         raise NotImplementedError
 
     def add_vlr(self, value):
         return
-   
+
     def get_vlrs(self):
         return(self.reader.get_vlrs())
 
@@ -1296,7 +1304,7 @@ class HeaderManager(object):
     evlrs = property(get_evlrs, set_evlrs, None, None)
 
     def get_srs(self):
-        raise NotImplementedError 
+        raise NotImplementedError
 
     def set_srs(self, value):
         raise NotImplementedError


### PR DESCRIPTION
This is a work in progress, but LAZ decompression support is now available with the lazperf library, and this demonstrates how to use it to decompress a file into memory.