### PR TITLE
Feature/scaled extra bytes

### DIFF
--- a/laspy/base.py
+++ b/laspy/base.py
@@ -894,6 +894,19 @@ class FileManager(object):
         else:
             raise laspy.util.LaspyException("Extra bytes not present in record")
 
+    def get_named_extra_bytes(self, name, eb_struct, scale = False, offset = False):
+        if not scale and not offset:
+            return(self.get_dimension(name))
+        elif scale and offset:
+            print "WARNING: Extra bytes with multiple dimensions not completely implemented! Using scale[0] and offset[0]"
+            return(self.get_dimension(name)*eb_struct.scale[0] + eb_struct.offset[0])
+        elif scale and not offset:
+            print "WARNING: Extra bytes with multiple dimensions not completely implemented! Using scale[0]"
+            return(self.get_dimension(name)*eb_struct.scale[0])
+        else: # not scale and offset:
+            print "WARNING: Extra bytes with multiple dimensions not completely implemented! Using offset[0]"
+            return(self.get_dimension(name) + eb_struct.offset[0])
+
 
 class Reader(FileManager):
     '''Just a subclass of FileManager'''
@@ -1371,6 +1384,23 @@ class Writer(FileManager):
             return
         self.set_dimension("X", np.round((X - self.header.offset[0])/self.header.scale[0]))
         return
+
+    def set_named_extra_bytes(self, name, eb_struct, value, scale = False, offset = False):
+        if not scale and not offset:
+            self.set_dimension(name, value)
+            return
+        if scale and offset:
+            print "WARNING: Extra bytes with multiple dimensions not completely implemented! Using scale[0] and offset[0]"
+            self.set_dimension(name, np.round((value - eb_struct.offset[0])/eb_struct.scale[0]))
+            return
+        if scale and not offset:
+            print "WARNING: Extra bytes with multiple dimensions not completely implemented! Using scale[0]"
+            self.set_dimension(name, np.round(value/eb_struct.scale[0]))
+            return
+        if not scale and offset:
+            print "WARNING: Extra bytes with multiple dimensions not completely implemented! Using offset[0]"
+            self.set_dimension(name, np.round(value - eb_struct.offset[0]))
+            return
 
     def set_y(self,Y, scale = False):
         '''Wrapper for set_dimension("Y", new_dimension)'''

--- a/laspy/file.py
+++ b/laspy/file.py
@@ -86,7 +86,7 @@ class File(object):
             if self._reader.extra_dimensions != []:
                 for dimension in self._reader.extra_dimensions:
                     dimname = dimension.name.decode().replace("\x00", "").replace(" ", "_").lower()
-                    self.addProperty(dimname)
+                    self.addProperty(dimname.capitalize())
 
 
         elif self._mode == 'rw':
@@ -98,7 +98,7 @@ class File(object):
                 if self._writer.extra_dimensions != []:
                     for dimension in self._writer.extra_dimensions:
                         dimname = dimension.name.decode().replace("\x00", "").replace(" ", "_").lower()
-                        self.addProperty(dimname) 
+                        self.addProperty(dimname.capitalize())
             else:
                 raise util.LaspyException("Headers must currently be stored in the file, you provided: " + str(self._header))
     
@@ -126,7 +126,7 @@ class File(object):
             if self._writer.extra_dimensions != []:
                 for dimension in self._writer.extra_dimensions:
                     dimname = dimension.name.decode().replace("\x00", "").replace(" ", "_").lower()
-                    self.addProperty(dimname) 
+                    self.addProperty(dimname.capitalize())
 
         elif self._mode == 'w+':
             raise NotImplementedError

--- a/laspy/file.py
+++ b/laspy/file.py
@@ -87,6 +87,8 @@ class File(object):
                 for dimension in self._reader.extra_dimensions:
                     dimname = dimension.name.decode().replace("\x00", "").replace(" ", "_").lower()
                     self.addProperty(dimname.capitalize())
+                    if dimension.is_scale_relevant() or dimension.is_offset_relevant():
+                        self.addProperty(dimname)
 
 
         elif self._mode == 'rw':
@@ -99,6 +101,8 @@ class File(object):
                     for dimension in self._writer.extra_dimensions:
                         dimname = dimension.name.decode().replace("\x00", "").replace(" ", "_").lower()
                         self.addProperty(dimname.capitalize())
+                        if dimension.is_scale_relevant() or dimension.is_offset_relevant():
+                            self.addProperty(dimname)
             else:
                 raise util.LaspyException("Headers must currently be stored in the file, you provided: " + str(self._header))
     
@@ -127,6 +131,8 @@ class File(object):
                 for dimension in self._writer.extra_dimensions:
                     dimname = dimension.name.decode().replace("\x00", "").replace(" ", "_").lower()
                     self.addProperty(dimname.capitalize())
+                    if dimension.is_scale_relevant() or dimension.is_offset_relevant():
+                        self.addProperty(dimname)
 
         elif self._mode == 'w+':
             raise NotImplementedError

--- a/laspy/header.py
+++ b/laspy/header.py
@@ -289,6 +289,19 @@ class ExtraBytesStruct(object):
         self.set_property(self, "description")
     description = property(get_description, set_description, None, None)
 
+    # The following methods return information from the options field
+    # See Table 25 of the LAS specification 1.4
+    def is_no_data_relevant(self):
+        return bool(self.get_property("options") & 1)
+    def is_min_relevant(self):
+        return bool((self.get_property("options") >> 1) & 1)
+    def is_max_relevant(self):
+        return bool((self.get_property("options") >> 2) & 1)
+    def is_scale_relevant(self):
+        return bool((self.get_property("options") >> 3) & 1)
+    def is_offset_relevant(self):
+        return bool((self.get_property("options") >> 4) & 1)
+
         
 class EVLR(ParseableVLR):
     ''' An extended VLR as defined in LAS specification 1.4'''

--- a/laspy/util.py
+++ b/laspy/util.py
@@ -350,7 +350,8 @@ class Format():
         
     
     def translate_extra_spec(self, extra_dim):
-        name = extra_dim.name.decode().replace("\x00", "").replace(" ", "_").lower()
+        # Name is capitalized because it represents raw data
+        name = extra_dim.name.decode().replace("\x00", "").replace(" ", "_").lower().capitalize()
         if extra_dim.data_type == 0:
             fmt = "ctypes.c_ubyte"
             num = extra_dim.options


### PR DESCRIPTION
This PR is a WIP related to #64. 

- Currently only extra bytes with dimension 1 are properly supported. A warning is printed to notify the user about that.
- I only tested the reading of extra bytes.
- The writing method is coded but not tested. Again, only works for vectors of dimension 1.

Sharing it here for analysis of the developers. Pointers of how to handle extra bytes with size 2 or 3 are welcome. 