### PR TITLE
Workaround for error with Version 1.4 file

### DIFF
--- a/laspy/base.py
+++ b/laspy/base.py
@@ -80,6 +80,10 @@ class FakeMmap(object):
             self.pos += nbytes
 
     def read(self, nbytes):
+        try:
+            nbytes = int(nbytes)
+        except ValueError:
+            nbytes = 0
         out = self.view[self.pos:self.pos+nbytes]
         self.pos += nbytes
         return(out)
@@ -492,14 +496,15 @@ class FileManager(object):
         outData = []
         for i in xrange(num):
             dat = self.read(bytes)
-            unpacked = struct.unpack(fmt, dat)[0]
-            if fmt == '<s':
-                try:
+            try:
+                unpacked = struct.unpack(fmt, dat)[0]
+                if fmt == '<s':
+                    struct.unpack(fmt, dat)[0]
                     unpacked = unpacked.decode('ascii')
-                except UnicodeDecodeError:
-                    # this is often NULs and random data that occurs after the
-                    # ending NUL.
-                    unpacked = '\x00'
+            except (struct.error, UnicodeDecodeError):
+                # this is often NULs and random data that occurs after the
+                # ending NUL.
+                unpacked = '\x00'
             outData.append(unpacked)
         if len(outData) > 1:
             return(outData)


### PR DESCRIPTION
I'm not 100% sure what's going on here, but I have these two files that seem to misbehave.  For what it's worth, they also crash FuegroViewer but GlobalMapper reads them fine:

https://drive.google.com/drive/folders/1jWwgP3p58_2gwqHGOWtEDHiGAAmbY-lM?usp=sharing

Something tries to unpack bad data or misinterpreted data as the short.  If this is bypassed and the null character is returned, then eventually read is called with nbytes null character.  Fixing these two issues allows the file to pass, but it's a downstream fix and not an upstream fix for whatever may be sending the bad data down.

Possibly related to #91 ?