### PR TITLE
minor typo bugfixes: blue/green order, get-set

### DIFF
--- a/laspy/base.py
+++ b/laspy/base.py
@@ -1641,7 +1641,7 @@ class Writer(FileManager):
         self.set_dimension("blue", blue)
 
     def set_nir(self, value):
-        self.get_dimension("nir", value)
+        self.set_dimension("nir", value)
 
     def set_wave_packet_desc_index(self, idx):
         '''Wrapper for set_dimension("wave_packet_desc_index") This is not currently functional,

--- a/laspy/util.py
+++ b/laspy/util.py
@@ -315,8 +315,8 @@ class Format():
             self.add("gps_time", "ctypes.c_double", 1)
         if fmt in ("7", "8", "10"):
             self.add("red", "ctypes.c_ushort", 1)
-            self.add("blue", "ctypes.c_ushort", 1)
             self.add("green", "ctypes.c_ushort", 1)
+            self.add("blue", "ctypes.c_ushort", 1)
         if fmt in ("8", "10"):
             self.add("nir", "ctypes.c_ushort", 1)
         if fmt in ("9", "10"):


### PR DESCRIPTION
+ Found that blue and green were referenced in the wrong order for point formats 7, 8, 10
+ Found an instance where `get_dimension` should be `set_dimension` when handling NIR

Also: `laspy` is great! Thanks to everyone for the great work you've put into it!