### PR TITLE
fix bug in point record format 5, 9 and 10

### DIFF
--- a/laspy/util.py
+++ b/laspy/util.py
@@ -296,7 +296,7 @@ class Format():
             elif fmt == "5":
                 self.add("wave_packet_desc_index", "ctypes.c_ubyte", 1)
                 self.add("byte_offset_to_waveform_data", "ctypes.c_ulonglong",1)
-                self.add("wavefm_pkt_size", "ctypes.c_ulong", 1)
+                self.add("waveform_packet_size", "ctypes.c_ulong", 1)
                 self.add("return_point_waveform_loc", "ctypes.c_float", 1)
                 self.add("x_t", "ctypes.c_float", 1)
                 self.add("y_t", "ctypes.c_float", 1)          
@@ -322,7 +322,7 @@ class Format():
         if fmt in ("9", "10"):
             self.add("wave_packet_desc_index", "ctypes.c_ubyte", 1)
             self.add("byte_offset_to_waveform_data", "ctypes.c_ulonglong",1)
-            self.add("wavefm_pkt_size", "ctypes.c_ulong", 1)
+            self.add("waveform_packet_size", "ctypes.c_ulong", 1)
             self.add("return_point_waveform_loc", "ctypes.c_float", 1)
             self.add("x_t", "ctypes.c_float", 1)
             self.add("y_t", "ctypes.c_float", 1)          


### PR DESCRIPTION
fix bug in point record format 5, 9 and 10: waveform_packet_size instead of wavefm_pkt_size that does not exist in File getter/setter