### PR TITLE
more explicit msg if laszip executable was not found

### DIFF
--- a/laspy/base.py
+++ b/laspy/base.py
@@ -39,7 +39,7 @@ def read_compressed(filename):
             laszip_binary = binary
             break
     else:
-        raise(laspy.util.LaspyException("Laszip was not found on the system"))
+        raise(laspy.util.LaspyException("laszip executable (%s) was not found in PATH" % ", ".join(laszip_names)))
 
     prc=subprocess.Popen([laszip_binary, "-olas", "-stdout", "-i", filename],
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=-1)


### PR DESCRIPTION
Fixes https://github.com/laspy/laspy/issues/109

Before: 'Laszip was not found on the system'
After: 'laszip executable (laszip, laszip.exe, laszip-cli, laszip-cli.exe) was not found in PATH'