### PR TITLE
Relax requirement for extra dimensions to have lower case names

### DIFF
--- a/laspy/base.py
+++ b/laspy/base.py
@@ -720,7 +720,7 @@ class FileManager(object):
             return(self._get_dimension(spec))
         except KeyError:
             raise laspy.util.LaspyException("Dimension: " + str(name) +
-                            " not found.")
+                            " not found. Existing dimensions: " + ", ".join(self.point_format.lookup.keys()))
 
     def _get_dimension(self, spec):
         return(self.data_provider._pmap["point"][spec.name])
@@ -1268,7 +1268,7 @@ class Writer(FileManager):
             return(self._set_dimension(spec, new_dim))
         except KeyError:
             raise laspy.util.LaspyException("Dimension: " + str(name) +
-                            "not found.")
+                            " not found. Existing dimensions: " + ", ".join(self.point_format.lookup.keys()))
 
     def _set_dimension(self, spec, value):
         self.data_provider._pmap["point"][spec.name] = value

--- a/laspy/header.py
+++ b/laspy/header.py
@@ -467,7 +467,7 @@ class VLR(ParseableVLR):
                 self.add_extra_dim(new_rec)
         
     def add_extra_dim(self, new_rec):
-        new_name = new_rec.name.decode().replace("\x00", "").replace(" ", "_").lower()
+        new_name = new_rec.name.decode().replace("\x00", "").replace(" ", "_")
         self.__dict__[new_name] = new_rec
         self.extra_dimensions.append(new_rec)
 

--- a/laspy/util.py
+++ b/laspy/util.py
@@ -354,7 +354,7 @@ class Format():
         
     
     def translate_extra_spec(self, extra_dim):
-        name = extra_dim.name.decode().replace("\x00", "").replace(" ", "_").lower()
+        name = extra_dim.name.decode().replace("\x00", "").replace(" ", "_")
         if extra_dim.data_type == 0:
             fmt = "ctypes.c_ubyte"
             num = extra_dim.options

--- a/laspytest/test_laspy.py
+++ b/laspytest/test_laspy.py
@@ -771,11 +771,11 @@ class LasV_14TestCase(unittest.TestCase):
         """Testingi multiple v1.4 VLR defined dimensions (LL API)"""
         new_header = self.File1.header.copy()
         # Test basic numeric dimension
-        new_dim_record1 = header.ExtraBytesStruct(name = "Test Dimension 1234", data_type = 5)
+        new_dim_record1 = header.ExtraBytesStruct(name = "test dimension 1234", data_type = 5)
         # Test string dimension (len 3)
-        new_dim_record2 = header.ExtraBytesStruct(name = "Test Dimension 5678", data_type = 22)
+        new_dim_record2 = header.ExtraBytesStruct(name = "test dimension 5678", data_type = 22)
         # Test integer array dimension (len 3)
-        new_dim_record3 = header.ExtraBytesStruct(name = "Test Dimension 9", data_type =  26)
+        new_dim_record3 = header.ExtraBytesStruct(name = "test dimension 9", data_type =  26)
         new_VLR_rec = header.VLR(user_id = "LASF_Spec", record_id = 4,
             VLR_body = (new_dim_record1.to_byte_string() + new_dim_record2.to_byte_string() + new_dim_record3.to_byte_string()))
         new_header.data_record_length += (19)
@@ -859,6 +859,17 @@ class LasV_14TestCase(unittest.TestCase):
         self.assertEqual(File2.test_dimension[500], 0)
         self.assertEqual(File2.test_dimension2[123], 0)
         File2.close(ignore_header_changes = True)
+
+    def test_vlr_defined_dimensions3(self):
+        """Testing VLR defined dimensions (HL API)"""
+        File2 = File.File(self.output_tempfile, mode = "w", header = self.File1.header)
+        File2.define_new_dimension("Test_Dimension", 5, "This is a test.")
+
+        File2.X = self.File1.X
+        self.assertEqual(File2.Test_Dimension[500], 0)
+        File2.close(ignore_header_changes = True)
+
+
 
     def tearDown(self):
         self.File1.close()


### PR DESCRIPTION
Relax extra dim creation requirements - standard doesn't require lower case names. 

Also updated tests accordingly, and added more helpful error messages upon failure. 