### PR TITLE
remove note about unscaled header extent values

### DIFF
--- a/doc/source/tut_background.rst
+++ b/doc/source/tut_background.rst
@@ -33,17 +33,6 @@ the Day+Year fields into a python :obj:`datetime.datetime` object, and placing
 the X Y and Z scale and offset values together. 
 
 
-.. note::
-
-    The various LAS specifications say that the Max and Min X Y Z fields store unscaled values, however
-    LAS data in the wild appears not to follow this convention. Therefore, by default, laspy stores
-    the scaled double precision values and updates header files accordingly on file close. This can be 
-    overridden by supplying one of several optional arguments to file.close(). First, 
-    you can simply not update the header at all, by specifying  ignore_header_changes=True.
-    Second, you can ask that laspy store the unscaled values explicitly, by specifying minmax_mode="unscaled".
-
-    If this sounds like gibberish, feel free to ignore it!
-
 **Header: Version 1.0 - 1.2**
 
 ===============================  ==============================  ==============================


### PR DESCRIPTION
By *unscaled*, the LAS spec actually means what laspy calls *scaled*.

However this potential source of confusion will likely be addressed in the new spec version: https://github.com/ASPRSorg/LAS/issues/89