### PR TITLE
Removed count from np.frombuffer

### DIFF
--- a/laspy/base.py
+++ b/laspy/base.py
@@ -227,8 +227,7 @@ class DataProvider():
         else:
             np_frombuffer_data = _prepare_np_frombuffer_data(self._mmap)
             self._pmap = np.frombuffer(np_frombuffer_data, self.pointfmt,
-                                       offset=self.manager.header.data_offset,
-                                       count=self.manager.header.point_records_count)
+                                       offset=self.manager.header.data_offset)
 
     def close(self, flush=True):
         '''Close the data provider and flush changes if _mmap and _pmap exist.'''

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ setup(name='laspy',
       packages=['laspy', 'laspy.tools'],
       test_suite='test.test_laspy',
       data_files=[("test/data",
-                  ["simple.las", "simple1_3.las",
-                   "simple1_4.las", "simple.laz"])],
+                  ["test/data/simple.las", "test/data/simple1_3.las",
+                   "test/data/simple1_4.las", "test/data/simple.laz"])],
       install_requires=['numpy'],
       extras_require={
           "laz": 'lazperf ; platform_system!="Windows"'


### PR DESCRIPTION
We are using laspy with several different point cloud versions, scanners and formats and recognized that in some newer LAS version 1.3 files we get a ValueError when we read the `numpy` buffer and `count` is defined for `np.frombuffer`. With this change laspy can read all LAS files without errors.

Tested with `numpy==1.20.2` `laspy==1.8.0` (master build). 

The `setup.py` was modified to be compatible with pip `21.0.1`.