### PR TITLE
Improve assigning to multiple fields of point record

### DIFF
--- a/laspy/lasreader.py
+++ b/laspy/lasreader.py
@@ -110,12 +110,8 @@ class LasReader:
     def read(self) -> LasData:
         """Reads all the points not read and returns a LasData object"""
         points = self.read_points(-1)
-        if not points:
-            points = record.PackedPointRecord.empty(self.header.point_format)
-        else:
-            points = record.PackedPointRecord(points.array, points.point_format)
-
         las_data = LasData(header=self.header, points=points)
+
         if self.header.version.minor >= 4:
             if (
                 self.header.are_points_compressed


### PR DESCRIPTION
It will now be possible to assign to many fields
of a `LasData` at once:

```Python
las = laspy.read(file)

las[['x', 'y', 'z']] = np.ones(len(las), dtype='3f8')

las[['red', 'green', 'blue']] = np.ones((len(las), 3), dtype='u2')
```

---

Internal changes are:
  - `LasData` now uses a `ScaleAwarePointRecord` to share behaviour
    of (x , y, z scaled dimentions)
  - Implement `PackedPointRecord.__setitem__(key, value)` to handle
    the case when the key is a list/tuple of dimension name.

Should improve #166 