### PR TITLE
Update required lazrs version to support LAZ with variable size chunks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
             "black==20.8b1",
             "pytest-benchmark",
         ],
-        "lazrs": ["lazrs>=0.3.1, < 0.4.0"],
+        "lazrs": ["lazrs>=0.4.0, < 0.5.0"],
         "laszip": ["laszip >= 0.1.0, < 0.2.0"],
     },
     include_package_data=True,


### PR DESCRIPTION
Bump the minimum required lazrs version to 0.4.0 as it brings the ability ro read
LAZ files with variable size chunks which are going to be used a bit more
as COPC spec utilizes the variable size chunks fearture of LAZ.

The laszip backend already supports variable size chunks.

This does not add an API to write LAZ files with variable size chunks

Also change LasAppender to work with lazrs changes