### PR TITLE
CI: Add Python 3.10 to build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: [ 3.6, 3.7, 3.8, 3.9 ]
+        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10" ]
         laz-backend: [ None, lazrs, laszip ]
 
     steps:


### PR DESCRIPTION
Add Python 3.10 to the GitHub Actions build matrix.

This PR is currently blocked by: https://github.com/tmontaigu/laszip-python/pull/1.