### PR TITLE
Add ability to remove extra dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Added a better error message when reading empty files
 - Added a new `xyz` attribute to `LasData` that returns x, y, z as a new numpy array or sets the x, y, z from an array
+- Added `LasData.remove_extra_dim` and `LasData.remove_extra_dims` to allow the removal of extra dimensions (__only__)
 
 ### Changed
 - Minimum `lazrs` version updated to 0.4.0 to bring support for LAZ with variable size chunks

--- a/laspy/header.py
+++ b/laspy/header.py
@@ -4,7 +4,7 @@ import logging
 import struct
 import typing
 from datetime import date, timedelta
-from typing import NamedTuple, BinaryIO, Optional, List, Union
+from typing import NamedTuple, BinaryIO, Optional, List, Union, Iterable
 from uuid import UUID
 
 import numpy as np
@@ -398,6 +398,14 @@ class LasHeader:
 
     def add_extra_dim(self, params: ExtraBytesParams):
         self.add_extra_dims([params])
+
+    def remove_extra_dim(self, name: str) -> None:
+        self.remove_extra_dims([name])
+
+    def remove_extra_dims(self, names: Iterable[str]) -> None:
+        for name in names:
+            self.point_format.remove_extra_dimension(name)
+        self._sync_extra_bytes_vlr()
 
     def set_version_and_point_format(
         self, version: Version, point_format: PointFormat

--- a/laspy/point/format.py
+++ b/laspy/point/format.py
@@ -196,6 +196,26 @@ class PointFormat:
             raise LaspyException("Extra Dimensions do not support more than 3 elements")
         self.dimensions.append(dim_info)
 
+    def remove_extra_dimension(self, name: str) -> None:
+        dimensions = [
+            dim for dim in self.dimensions if dim.name == name and not dim.is_standard
+        ]
+
+        try:
+            dimension = dimensions[0]
+        except IndexError:
+            if name in self.standard_dimension_names:
+                raise LaspyException(
+                    f"The dimension named '{name}' is not an extra dimension, "
+                    "so it cannot be removed"
+                )
+            else:
+                raise LaspyException(
+                    f"'No extra dimension named '{name}' exist"
+                ) from None
+
+        self.dimensions = [dim for dim in self.dimensions if dim is not dimension]
+
     def dtype(self):
         """Returns the numpy.dtype used to store the point records in a numpy array
 


### PR DESCRIPTION
This adds `LasData.remove_extra_dim` and
`LasData.remove_extra_dims` to allow users to remove
extra dimensions (and __only__ extra dimensions) from
a LasData object.

Fixes #179