### PR TITLE
Fix las.x, las.y, las.z not setting X, Y or Z

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Fixed regression introduced in 2.1.0 where setting the x, y or z value would not properly set the corresponding
+  X, Y or Z value.
+
 ## 2.1.0
 
 ### Added

--- a/laspy/lasdata.py
+++ b/laspy/lasdata.py
@@ -354,6 +354,7 @@ class LasData:
         if (
             key in self.point_format.dimension_names
             or key in self.points.array.dtype.names
+            or key in ("x", "y", "z")
         ):
             self.points[key] = value
         elif key in dims.DIMENSIONS_TO_TYPE:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -326,3 +326,64 @@ def test_change_scaling():
     assert np.all(las.X == [0, 2, 4, 6])
     assert np.all(las.Y == [-190, -180, -170, -160])
     assert np.all(las.Z == [-2900, -2800, -2700, -2600])
+
+
+def test_setting_x_y_z_on_las_data():
+    """
+    The goal of this test if to make sure that when setting the `x`,`y` and `z`
+    attribute of a LasData object, the X,Y,Z version of the coordinates
+    are properly set in the inner point record
+    """
+    las = laspy.read(simple_las)
+
+    new_las = laspy.create()
+
+    new_las.x = las.x
+    new_las.y = las.y
+    new_las.z = las.z
+
+    assert np.all(new_las.x == las.x)
+    assert np.all(new_las.X == las.X)
+    assert np.all(new_las.y == las.y)
+    assert np.all(new_las.Y == las.Y)
+    assert np.all(new_las.z == las.z)
+    assert np.all(new_las.Z == las.Z)
+
+
+    new_las = laspy.lib.write_then_read_again(new_las)
+
+    assert np.all(new_las.x == las.x)
+    assert np.all(new_las.X == las.X)
+    assert np.all(new_las.y == las.y)
+    assert np.all(new_las.Y == las.Y)
+    assert np.all(new_las.z == las.z)
+    assert np.all(new_las.Z == las.Z)
+
+
+def test_setting_xyz_on_las_data():
+    """
+    The goal of this test if to make sure that when setting the `xyz`
+    attribute of a LasData object, the X,Y,Z version of the coordinates
+    are properly set in the inner point record
+    """
+    las = laspy.read(simple_las)
+
+    new_las = laspy.create()
+
+    new_las.xyz = las.xyz
+
+    assert np.all(new_las.x == las.x)
+    assert np.all(new_las.X == las.X)
+    assert np.all(new_las.y == las.y)
+    assert np.all(new_las.Y == las.Y)
+    assert np.all(new_las.z == las.z)
+    assert np.all(new_las.Z == las.Z)
+
+    new_las = laspy.lib.write_then_read_again(new_las)
+
+    assert np.all(new_las.x == las.x)
+    assert np.all(new_las.X == las.X)
+    assert np.all(new_las.y == las.y)
+    assert np.all(new_las.Y == las.Y)
+    assert np.all(new_las.z == las.z)
+    assert np.all(new_las.Z == las.Z)


### PR DESCRIPTION
This fixes the regression introduced by commit 8426cbc2991f88d64dbde336904199126a989a4d
where setting x, y or z like: `las.x = some_array` would not properly set `las.X` like it used to
and like it should.

When doing `las.x = ...` (or `.y`, or `.z`)
`___setattr__` was called, this would then call `super().__setattr__(key, value)`.

The commit 8426cbc2991f88d64dbde336904199126a989a4d removed the
x, y and z propeties (getter and setter), so `super().__setattr__(key, value)` would then create
a new attribute called `x` on the LasData instance instead of calling the `x` property setter
that handled the details that needs to be taken care of (setting the X values in the actual point record array).

We fix this by making the `___setattr__`  call to forward the call to the inner `ScaleAwarePointRecord`
so that the X, Y or Z values are actually set.

Fixes issue #189