### PR TITLE
Fix header.update mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- Fixed `LasHeader.update` (thus fixing `LasData.update_header`) computation of x,y,z mins and maxs
+
 ## 2.1.1
 
 ### Fixed

--- a/laspy/header.py
+++ b/laspy/header.py
@@ -416,16 +416,25 @@ class LasHeader:
 
     def partial_reset(self) -> None:
         self.creation_date = date.today()
-        self.point_count = 0
 
-        self.maxs = np.zeros(3, dtype=np.float64)
-        self.mins = np.zeros(3, dtype=np.float64)
-        self.number_of_points_by_return = np.zeros(15, dtype=np.uint32)
+        f64info = np.finfo(np.float64)
+        self.maxs = np.ones(3, dtype=np.float64) * f64info.min
+        self.mins = np.ones(3, dtype=np.float64) * f64info.max
 
         self.start_of_first_evlr = 0
         self.number_of_evlrs = 0
+        self.point_count = 0
+        self.number_of_points_by_return = np.zeros(15, dtype=np.uint32)
 
     def update(self, points: PackedPointRecord) -> None:
+        self.partial_reset()
+        if not points:
+            self.maxs = [0.0, 0.0, 0.0]
+            self.mins = [0.0, 0.0, 0.0]
+        else:
+            self.grow(points)
+
+    def grow(self, points: PackedPointRecord) -> None:
         self.x_max = max(
             self.x_max,
             (points["X"].max() * self.x_scale) + self.x_offset,

--- a/laspy/lasappender.py
+++ b/laspy/lasappender.py
@@ -82,7 +82,7 @@ class LasAppender:
             raise LaspyException("Point formats do not match")
 
         self.points_writer.write_points(points)
-        self.header.update(points)
+        self.header.grow(points)
 
     def close(self) -> None:
         self.points_writer.done()

--- a/laspy/lasdata.py
+++ b/laspy/lasdata.py
@@ -211,8 +211,7 @@ class LasData:
         self.header.point_format_id = self.points.point_format.id
         self.header.point_data_record_length = self.points.point_size
 
-        if len(self.points) > 0:
-            self.header.update(self.points)
+        self.header.update(self.points)
 
         if self.header.version.minor >= 4:
             if self.evlrs is not None:

--- a/laspy/laswriter.py
+++ b/laspy/laswriter.py
@@ -72,8 +72,6 @@ class LasWriter:
         self.encoding_errors = encoding_errors
         self.header = deepcopy(header)
         self.header.partial_reset()
-        self.header.maxs = [np.finfo("f8").min] * 3
-        self.header.mins = [np.finfo("f8").max] * 3
 
         self.dest = dest
         self.done = False
@@ -132,7 +130,7 @@ class LasWriter:
         if points.point_format != self.header.point_format:
             raise LaspyException("Incompatible point formats")
 
-        self.header.update(points)
+        self.header.grow(points)
         self.point_writer.write_points(points)
 
     def write_evlrs(self, evlrs: VLRList) -> None:
@@ -169,6 +167,11 @@ class LasWriter:
         if self.point_writer is not None:
             if not self.done:
                 self.point_writer.done()
+
+            if self.header.point_count == 0:
+                self.header.maxs = [0.0, 0.0, 0.0]
+                self.header.mins = [0.0, 0.0, 0.0]
+
             self.point_writer.write_updated_header(self.header, self.encoding_errors)
         if self.closefd:
             self.dest.close()


### PR DESCRIPTION
The `update` function of the `LasHeader` was written in a way
that made it compute the correct x,y,z bound when writing in chunk mode.

`update` computed the bounds by "growing" them, which is the right strategy
for chunk mode writing, but not when you juste want to update the header
to match the values  after slicing or setting the `LasData.points`.

We fix this by adding a `grow` method to the header and use it in appropriate places
and the `update` is changed to actually match the set of point given.

Fixes #194 