### PR TITLE
Fix _append_zeros_if_too_small

### DIFF
--- a/laspy/point/record.py
+++ b/laspy/point/record.py
@@ -139,9 +139,8 @@ class PackedPointRecord:
         """Appends zeros to the points stored if the value we are trying to
         fit is bigger
         """
-        size_diff = len(value) - len(self.array)
-        if size_diff > 0:
-            self.resize(size_diff)
+        if len(value) > len(self.array):
+            self.resize(len(value))
 
     def __eq__(self, other):
         return self.point_format == other.point_format and np.all(


### PR DESCRIPTION
In `_append_zeros_if_too_small` instead of resizing the internal point array
to have the same size as the input array length we resized to
the difference in length.

Meaning the copy of values that would happen right after would
fail with an error like:
`ValueError: could not broadcast input array from shape (x,) into shape (y,)`

Example:
If the internal array had length 1 and input array had length 1000, we would
resize to 1000 - 1 = 999 element. And we would get this error later:
`ValueError: could not broadcast input array from shape (1000,) into shape (999,)`

Now we will properly resize to the correct length (1000 in the example)

- [ ] edit changelog