### PR TITLE
Remove python 3.6 from supported versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
         laz-backend: [ None, lazrs, laszip ]
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.1.2
 
+### Changed
+
+- Support for Python3.6 removed.
+
 ### Fixed
 - Fixed `LasHeader.update` (thus fixing `LasData.update_header`) computation of x,y,z mins and maxs
 - Fixed regression introduced in 2.1.0 where changing the `header.scales` and/or `header.offsets`

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Laspy is a python library for reading, modifying and creating LAS LiDAR
 files.
 
-Laspy is compatible with Python  3.6+.
+Laspy is compatible with Python  3.7+.
 
 
 Examples

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,7 +1,7 @@
 import nox
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9"])
+@nox.session(python=["3.7", "3.8", "3.9", "3.10"])
 @nox.parametrize("laz_backend", [None, "lazrs", "laszip"])
 def tests(session, laz_backend):
     session.install("pytest")

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     long_description=readme,
     long_description_content_type="text/markdown",
     packages=find_packages(exclude=("tests",)),
+    python_requires=">=3.7",
     install_requires=["numpy", "pyproj"],
     extras_require={
         "dev": [


### PR DESCRIPTION
CPython 3.6 support ended on the 23rd Dec 2021.
This commit removes CPython 3.6 from the CI because we will no longer ensure we are
compatible. We can now use python 3.7 features