### PR TITLE
Improve CRS support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,15 +35,24 @@ jobs:
       if: matrix.laz-backend != 'None'
       run: pip install .[${{ matrix.laz-backend }}]
 
+    # We run pyproj tests when no laz backend is installed
+    # as its not correlated at all.
     - name: Install Without LAZ backend
       if: matrix.laz-backend == 'None'
-      run: pip install .
+      run: pip install .[pyproj]
+
+    # Some crs tests require pdal
+    # and its easier to install it on ubuntu
+    - name: Install pdal
+      if: matrix.laz-backend == 'None' && matrix.os == 'ubuntu-latest'
+      run: sudo apt install -y pdal
 
     - name: Run Tests
       run: |
         pip install pytest
         pytest tests
         pytest laspy
+
 
 
   formatting:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,26 @@
 # Changelog
 
-## 2.1.2
+
+## 2.2.0
+
+### Added
+- Added new optional feature to support adding CRS / SRS to a LAS file from a `pyproj.CRS` as 
+  well as reading the CRS / SRS information from a LAS file to a `pyproj.CRS`. 
 
 ### Changed
-
 - Support for Python3.6 removed.
+
+---
+  
+## 2.1.2
+
 
 ### Fixed
 - Fixed `LasHeader.update` (thus fixing `LasData.update_header`) computation of x,y,z mins and maxs
 - Fixed regression introduced in 2.1.0 where changing the `header.scales` and/or `header.offsets`
   on a `LasData` newly created  and then setting `x` `y` or `z` would produce incorrect result.
+
+---
 
 ## 2.1.1
 
@@ -19,6 +30,8 @@
 - Fixed `LasData.change_scaling` setting the header's `offsets` and/or `scales` to `None`
   if the corresponding optionnal argument was not given to the `change_scaling` method.
   The header will now correctly keep the corresponding value unchanged.
+
+---
 
 ## 2.1.0
 
@@ -42,12 +55,16 @@
 - Fix scaled extra byte creation when the offsets/scales given to `ExtraBytesParam` where of type `list` or `tuple`
 - Fix `ScaledArrayView` to allow indexing with `list` or `numpy.array`.
 
+---
+
 ## Version 2.0.3
 
 ## Fixed
 - Fix function that parses geotiff VLRs
 - Fix handling of points with 'unregistered' extra bytes (PR #158)
 - Fix to handle empty LAS/LAZ more robustly
+
+---
 
 ## Version 2.0.2
 
@@ -57,14 +74,18 @@
   - Improve memory usage when reading/writing. (issue #152)
 
 ### Fixed
-- Fix system_identifier reading by ignoring non ascii characters instead of erroring ,(issue #148, PR #149).
+- Fix `system_identifier` reading by ignoring non ascii characters instead of erroring ,(issue #148, PR #149).
 - Fix `LasData.change_scaling` method.
+
+---
 
 ## Version 2.0.1
 
 ### Fixed
 - Fix `.min` `.max` methods of array views
 - Ship the tests as part of the source distribution (But they won't be installed with `pip install`)
+
+---
 
 ## Version 2.0.0
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -35,8 +35,12 @@ still need to install a LAZ backend via ``pip``
 
 
 
-Optional dependencies for LAZ support
-=====================================
+Optional dependencies 
+=====================
+
+
+LAZ support
+___________
 
 laspy does not support LAZ (.laz) file by itself but can use one of several optional dependencies
 to support compressed LAZ files.
@@ -62,6 +66,15 @@ with waveform but does not offer multi-threaded compression/decompression.
 Both the laszip bindings and lazrs are available on pip.
 
 To install laspy with one of its supported backend use one of the following commands
+
+
+CRS / SRS
+_________
+
+LAS files allows to define the CRS / SRS in which the points coordinates are.
+When `pyproj` is installed, you can use the :meth:`.LasHeader.add_crs` to add 
+CRS information to a file, or you can use :meth:`.LasHeader.parse_crs` to get 
+`pyproj.CRS`.
 
 
 .. _lazrs: https://github.com/tmontaigu/laz-rs

--- a/laspy/vlrs/geotiff.py
+++ b/laspy/vlrs/geotiff.py
@@ -1,94 +1,162 @@
 import logging
-from collections import namedtuple
-from typing import List, Optional
+from typing import Tuple, Optional
 
-from . import vlrlist
-from .known import GeoAsciiParamsVlr, GeoDoubleParamsVlr, GeoKeyDirectoryVlr
+from .known import (
+    GeoAsciiParamsVlr,
+    GeoKeyDirectoryVlr,
+    GeoKeyEntryStruct,
+)
+from copy import copy
 
-GeoTiffKey = namedtuple("GeoTiffKey", ("id", "value"))
+try:
+    import pyproj
+except ModuleNotFoundError:
+    pass
+
 
 logger = logging.getLogger(__name__)
 
-GTModelTypeGeoKey = 1024
-GTRasterTypeGeoKey = 1025
-GTCitationGeoKey = 1026
-GeogCitationGeoKey = 2049
-GeogAngularUnitsGeoKey = 2054
-ProjectedCSTypeGeoKey = 3072
-ProjLinearUnitsGeoKey = 3076
+
+# GeoTIFF Configuration GeoKeys
+"""
+GeoTIFF defined CS Model Type Codes:
+   ModelTypeProjected   = 1   /* Projection Coordinate System         */
+   ModelTypeGeographic  = 2   /* Geographic latitude-longitude System */
+   ModelTypeGeocentric  = 3   /* Geocentric (X,Y,Z) Coordinate System */
+
+Notes:
+   1. ModelTypeGeographic and ModelTypeProjected
+      correspond to the FGDC metadata Geographic and
+      Planar-Projected coordinate system types.
+
+http://geotiff.maptools.org/spec/geotiff6.html#6.3.1.1
+"""
+ModelTypeProjected = 1
+ModelTypeGeographic = 2
+GTModelTypeGeoKey = GeoKeyEntryStruct(
+    id=1024,
+    tiff_tag_location=0,
+    count=1,
+)
+"""
+Values:
+0 => Undefined
+1 => RasterPixelIsArea
+2 => RasterPixelIsPoint
+
+http://geotiff.maptools.org/spec/geotiff6.html#6.3.1.2
+"""
+GTRasterTypeGeoKey = GeoKeyEntryStruct(
+    id=1025,
+    tiff_tag_location=0,
+    count=1,
+)
+"""
+'ASCII reference to published documentation on the overall configuration
+of this GeoTIFF file.'
+"""
+GTCitationGeoKey = GeoKeyEntryStruct(
+    id=1026,
+    tiff_tag_location=GeoAsciiParamsVlr.official_record_ids()[0],
+)
+
+# Geographic CS Parameter GeoKeys
+
+GeographicTypeGeoKey = GeoKeyEntryStruct(
+    id=2048,
+    tiff_tag_location=0,
+    count=1,
+)
+
+"""
+General citation and reference for all Geographic CS parameters.
+"""
+GeogCitationGeoKey = GeoKeyEntryStruct(
+    id=2049,
+    tiff_tag_location=GeoAsciiParamsVlr.official_record_ids()[0],
+)
+
+# Projected CS Parameter GeoKeys
+
+ProjectedCSTypeGeoKey = GeoKeyEntryStruct(
+    id=3072,
+    tiff_tag_location=0,
+    count=1,
+)
+
+"""
+'ASCII reference to published documentation on the 
+Projected Coordinate System particularly if this is a "user-defined" PCS'
+"""
+PCSCitationGeoKey = GeoKeyEntryStruct(
+    id=3073,
+    tiff_tag_location=GeoAsciiParamsVlr.official_record_ids()[0],
+)
+
+# Geographic CS Parameter GeoKeys
 
 
-def parse_geo_tiff_keys_from_vlrs(vlr_list: vlrlist.VLRList) -> List[GeoTiffKey]:
-    """Gets the 3 GeoTiff vlrs from the vlr_list and parse them into
-    a nicer structure
+def create_geotiff_projection_vlrs(
+    crs: "pyproj.CRS",
+) -> Tuple[GeoKeyDirectoryVlr, GeoAsciiParamsVlr]:
+    # 'Cookbook' from the geotiff spec
+    # http://geotiff.maptools.org/spec/geotiff2.7.html#2.7
 
-    Parameters
-    ----------
-    vlr_list: laspy.vrls.vlrslist.VLRList list of vlrs from a las file
+    if crs.is_projected:
+        model_key = copy(GTModelTypeGeoKey)
+        model_key.value_offset = ModelTypeProjected
 
-    Raises
-    ------
-        IndexError if any of the needed GeoTiffVLR is not found in the list
+        epsg_code = crs.to_epsg()
+        if epsg_code is None:
+            raise RuntimeError("Projected CRS without epsg is not supported")
 
-    Returns
-    -------
-    List of GeoTiff keys parsed from the VLRs
+        projected_crs_key = copy(ProjectedCSTypeGeoKey)
+        projected_crs_key.value_offset = epsg_code
 
-    """
-    geo_key_dir = vlr_list.get_by_id(
-        GeoKeyDirectoryVlr.official_user_id(), GeoKeyDirectoryVlr.official_record_ids()
-    )[0]
+        # Citation Keys for which data is stored in the Ascii Param
+        pcs_citation = crs.name.encode("ascii")
 
-    try:
-        geo_doubles = vlr_list.get_by_id(
-            GeoDoubleParamsVlr.official_user_id(),
-            GeoDoubleParamsVlr.official_record_ids(),
-        )[0]
-    except IndexError:
-        geo_doubles = None
+        ascii_params = b"|".join([pcs_citation])
 
-    try:
-        geo_ascii = vlr_list.get_by_id(
-            GeoAsciiParamsVlr.official_user_id(),
-            GeoAsciiParamsVlr.official_record_ids(),
-        )[0]
-    except IndexError:
-        geo_ascii = None
-    return parse_geo_tiff(geo_key_dir, geo_doubles, geo_ascii)
+        pcs_citation_key = copy(PCSCitationGeoKey)
+        pcs_citation_key.value_offset = 0
+        pcs_citation_key.count = len(pcs_citation)
 
+        keys = [model_key, projected_crs_key, pcs_citation_key]
+        geo_key_vlr = GeoKeyDirectoryVlr()
+        geo_key_vlr.geo_keys_header.number_of_keys = len(keys)
+        geo_key_vlr.geo_keys = keys
 
-def parse_geo_tiff(
-    key_dir_vlr: GeoKeyDirectoryVlr,
-    double_vlr: Optional[GeoDoubleParamsVlr],
-    ascii_vlr: Optional[GeoAsciiParamsVlr],
-) -> List[GeoTiffKey]:
-    """Parses the GeoTiff VLRs information into nicer structs"""
-    geotiff_keys = []
+        ascii_vlr = GeoAsciiParamsVlr()
+        ascii_vlr.strings = [ascii_params.decode("ascii")]
 
-    for k in key_dir_vlr.geo_keys:
-        if k.tiff_tag_location == 0:
-            value = k.value_offset
-        elif k.tiff_tag_location == 34736:
-            if double_vlr is None:
-                raise RuntimeError(
-                    "Geotiff tag location points to GeoDoubleParams, "
-                    "but it does not exists"
-                )
-            value = double_vlr.doubles[k.value_offset]
-        elif k.tiff_tag_location == 34737:
-            if ascii_vlr is None:
-                raise RuntimeError(
-                    "Geotiff tag location points to GeoAsciiParams, "
-                    "but it does not exists"
-                )
-            value = ascii_vlr.string(k.value_offset, k.count)
-        else:
-            logger.warning(
-                "GeoTiffKey with unknown tiff tag location ({})".format(
-                    k.tiff_tag_location
-                )
-            )
-            continue
+        return geo_key_vlr, ascii_vlr
+    if crs.is_geographic or crs.is_geocentric:
+        model_key = copy(GTModelTypeGeoKey)
+        model_key.value_offset = ModelTypeGeographic
 
-        geotiff_keys.append(GeoTiffKey(k.id, value))
-    return geotiff_keys
+        epsg_code = crs.to_epsg()
+        if epsg_code is None:
+            raise RuntimeError("Geographic CRS without epsg is not supported")
+
+        geographic_crs_key = copy(GeographicTypeGeoKey)
+        geographic_crs_key.value_offset = epsg_code
+
+        geodetic_citation = crs.geodetic_crs.name.encode("ascii")
+        ascii_params = b"|".join([geodetic_citation])
+
+        geodetic_citation_key = copy(GeogCitationGeoKey)
+        geodetic_citation_key.value_offset = 0
+        geodetic_citation_key.count = len(geodetic_citation)
+
+        keys = [model_key, geographic_crs_key, geodetic_citation_key]
+        geo_key_vlr = GeoKeyDirectoryVlr()
+        geo_key_vlr.geo_keys_header.number_of_keys = len(keys)
+        geo_key_vlr.geo_keys = keys
+
+        ascii_vlr = GeoAsciiParamsVlr()
+        ascii_vlr.strings = [ascii_params.decode("ascii")]
+        return geo_key_vlr, ascii_vlr
+
+    else:
+        raise RuntimeError(f"CRS of type {crs.type_name} is not supported")

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     long_description_content_type="text/markdown",
     packages=find_packages(exclude=("tests",)),
     python_requires=">=3.7",
-    install_requires=["numpy", "pyproj"],
+    install_requires=["numpy"],
     extras_require={
         "dev": [
             "pytest",
@@ -35,6 +35,7 @@ setup(
         ],
         "lazrs": ["lazrs>=0.4.0, < 0.5.0"],
         "laszip": ["laszip >= 0.1.0, < 0.2.0"],
+        "pyproj": ["pyproj"],
     },
     include_package_data=True,
     zip_safe=False,

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -1,8 +1,15 @@
 import pytest
-import pyproj
+import subprocess
+import os
+import json
 
 import laspy
 from tests.test_common import test1_4_las, autzen_las
+
+try:
+    import pyproj
+except ModuleNotFoundError:
+    pyproj = None
 
 
 @pytest.fixture()
@@ -14,15 +21,27 @@ def file_wkt():
 def file_geotiff():
     return laspy.read(autzen_las)
 
+def has_pyproj() -> bool:
+    return pyproj is not None
 
+
+@pytest.mark.skipif(
+    not has_pyproj(), reason="pyproj not installed"
+)
 def test_parse_crs_wkt(file_wkt):
     assert 'Bound CRS' in file_wkt.header.parse_crs().type_name
 
 
+@pytest.mark.skipif(
+    not has_pyproj(), reason="pyproj not installed"
+)
 def test_parse_crs_geotiff(file_geotiff):
     assert 'Projected CRS' in file_geotiff.header.parse_crs().type_name
 
 
+@pytest.mark.skipif(
+    not has_pyproj(), reason="pyproj not installed"
+)
 def test_add_crs_wkt():
     header = laspy.LasHeader(point_format=6, version="1.4")
     crs = pyproj.CRS.from_epsg(6432)
@@ -36,7 +55,13 @@ def test_add_crs_wkt():
     assert header.global_encoding.wkt
 
 
+@pytest.mark.skipif(
+    not has_pyproj(), reason="pyproj not installed"
+)
 def test_add_crs_geotiff():
+    """
+    Test adding geotiff crs seems ok
+    """
     header = laspy.LasHeader(point_format=3, version="1.2")
     crs = pyproj.CRS.from_epsg(6432)
     header.add_crs(crs)
@@ -49,6 +74,15 @@ def test_add_crs_geotiff():
     assert header.global_encoding.wkt == False
 
 
+    las = laspy.LasData(header=header)
+    las = laspy.lib.write_then_read_again(las)
+    epsg = las.header.parse_crs().to_epsg()
+    assert epsg == 6432, "epsg after read-write is not the same"
+
+
+@pytest.mark.skipif(
+    not has_pyproj(), reason="pyproj not installed"
+)
 def test_add_crs_compatibility():
     header = laspy.LasHeader(point_format=3, version="1.4")
     crs = pyproj.CRS.from_epsg(6432)
@@ -60,3 +94,64 @@ def test_add_crs_compatibility():
     assert hasattr(lasf_proj[0], 'string')
     assert lasf_proj[0].string == crs.to_wkt()
     assert header.global_encoding.wkt
+
+def has_pdal():
+    try:
+        subprocess.run(['pdal', '--version'], capture_output=True, check=True)
+    except:
+        return False
+    else:
+        return True
+
+
+def get_pdal_srs(filename):
+    process = subprocess.run(['pdal', 'info', '--metadata', filename], capture_output=True, check=True)
+    json_output = json.loads(process.stdout.decode('utf-8'))['metadata']['srs']
+    return json_output['wkt'], json_output['proj4']
+    
+
+def geotiff_crs_pdal_test(crs):
+    header = laspy.LasHeader(point_format=3, version="1.2")
+    header.add_crs(crs)
+
+    tmp_filename = f'delete_me_pdal_test_cs_{crs.to_epsg()}.las'
+
+    las = laspy.LasData(header=header)
+    las.write(tmp_filename)
+
+
+    try:
+        pdal_wkt, _ = get_pdal_srs(tmp_filename)
+
+    finally:
+        os.remove(tmp_filename)
+
+
+    # We don't use pdal's proj4 as its seems not complete enough
+    # to be 100% equal, while the wkt seems ok
+    assert pyproj.CRS.from_wkt(pdal_wkt) == crs
+
+
+@pytest.mark.skipif(
+    not (has_pdal() and has_pyproj()), reason="PDAL and/or pyproj not found"
+)
+def test_pdal_understands_our_geotiff_derived_projected_cs():
+    crs = pyproj.CRS.from_epsg(3945)
+    geotiff_crs_pdal_test(crs)
+    
+@pytest.mark.skipif(
+    not (has_pdal() and has_pyproj()), reason="PDAL and/or pyproj not found"
+)
+def test_pdal_understands_our_geotiff_geographic_cs():
+    crs = pyproj.CRS.from_epsg(4326)
+    geotiff_crs_pdal_test(crs)
+
+
+
+@pytest.mark.skipif(
+    not (has_pdal() and has_pyproj()), reason="PDAL and/or pyproj not found"
+)
+def test_pdal_understands_our_geotiff_projected_cs():
+    crs = pyproj.CRS.from_epsg(6432)
+    geotiff_crs_pdal_test(crs)
+

--- a/tests/test_vlrs.py
+++ b/tests/test_vlrs.py
@@ -51,8 +51,3 @@ def test_adding_extra_bytes_vlr_by_hand():
     assert simple.points.point_size == las.points.point_size
     assert len(las.vlrs.get("ExtraBytesVlr")) == 0
 
-
-def test_geokey_parsing_does_not_require_optional_params():
-    las = laspy.read(str(Path(__file__).parent / "data/simple1_3.las"))
-    geo_keys = laspy.vlrs.geotiff.parse_geo_tiff_keys_from_vlrs(las.vlrs)
-    assert len(geo_keys) == 6


### PR DESCRIPTION
This commit reworks a bit the CRS support that was added in `a2c0ac1`.

Mainly it generates the Geotiff VLRs containing the strict minimum
of information. (If some readers do not undertstand geotiff information
we wrote, then we will expand it)

- Fix adding / parsing geotiff crs for 'geographic' projections with EPSG
  such as `WGS 84` (epsg 4326)

Should fix #211 

TODO

- [x] improve the code itself
- [x] a bit of test
- [x] make pyproj optional