### PR TITLE
Fix support for non-seekable sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 ### Changed
 - Support for Python3.6 removed.
 
+### Fixed
+- Fixed support for stream / source that are not `seekable`.
+
 ---
   
 ## 2.1.2

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
             "pytest-benchmark",
             "m2r2",
         ],
-        "lazrs": ["lazrs>=0.4.0, < 0.5.0"],
+        "lazrs": ["lazrs>=0.4.3, < 0.5.0"],
         "laszip": ["laszip >= 0.1.0, < 0.2.0"],
         "pyproj": ["pyproj"],
     },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,11 +8,13 @@ SIMPLE_LAS_FILE_PATH = Path(__file__).parent / "data" / "simple.las"
 VEGETATION1_3_LAS_FILE_PATH = Path(__file__).parent / "data" / "vegetation_1_3.las"
 TEST1_4_LAS_FILE_PATH = Path(__file__).parent / "data" / "test1_4.las"
 EXTRA_BYTES_LAS_FILE_PATH = Path(__file__).parent / "data" / "extrabytes.las"
+LAS_1_4_WITH_EVLRS_FILE_PATH = Path(__file__).parent / "data" / "1_4_w_evlr.las"
 
 SIMPLE_LAZ_FILE_PATH = Path(__file__).parent / "data" / "simple.laz"
 EXTRA_BYTES_LAZ_FILE_PATH = Path(__file__).parent / "data" / "extra.laz"
 PLANE_LAZ_FILE_PATH = Path(__file__).parent / "data" / "plane.laz"
 AUTZEN_FILE_PATH = Path(__file__).parent / "data" / "autzen.las"
+LAZ_1_4_WITH_EVLRS_FILE_PATH = Path(__file__).parent / "data" / "1_4_w_evlr.laz"
 
 UNREGISTERED_EXTRA_BYTES_LAS = Path(__file__).parent / "data" / "unregistered_extra_bytes.las"
 

--- a/tests/test_chunk_read_write.py
+++ b/tests/test_chunk_read_write.py
@@ -9,6 +9,17 @@ import pytest
 
 import laspy
 
+def check_chunked_reading_gives_expected_points(
+    groundtruth_las: laspy.LasData, reader: laspy.LasReader, iter_size: int
+):
+    """Checks that the points read by the reader are the same as groundtruth points."""
+    assert groundtruth_las.point_format == reader.header.point_format
+    for i, points in enumerate(reader.chunk_iterator(iter_size)):
+        expected_points = groundtruth_las.points[i * iter_size : (i + 1) * iter_size]
+        for dim_name in points.array.dtype.names:
+            assert np.allclose(
+                expected_points[dim_name], points[dim_name]
+            ), f"{dim_name} not equal"
 
 def test_chunked_las_reading_gives_expected_points(las_file_path):
     """
@@ -17,8 +28,7 @@ def test_chunked_las_reading_gives_expected_points(las_file_path):
     with laspy.open(las_file_path) as las_reader:
         with laspy.open(las_file_path) as reader:
             las = las_reader.read()
-            check_chunked_reading_is_gives_expected_points(las, reader, iter_size=50)
-
+            check_chunked_reading_gives_expected_points(las, reader, iter_size=50)
 
 def test_chunked_laz_reading_gives_expected_points(laz_file_path, laz_backend):
     """
@@ -27,7 +37,7 @@ def test_chunked_laz_reading_gives_expected_points(laz_file_path, laz_backend):
     with laspy.open(laz_file_path) as las_reader:
         with laspy.open(laz_file_path, laz_backend=laz_backend) as laz_reader:
             expected_las = las_reader.read()
-            check_chunked_reading_is_gives_expected_points(
+            check_chunked_reading_gives_expected_points(
                 expected_las, laz_reader, iter_size=50
             )
 
@@ -59,23 +69,9 @@ def test_chunked_writing_gives_expected_points(file_path, backend):
 
         tmp_output.seek(0)
         with laspy.open(tmp_output, closefd=False) as reader:
-            check_chunked_reading_is_gives_expected_points(
+            check_chunked_reading_gives_expected_points(
                 original_las, reader, iter_size
             )
-
-
-def check_chunked_reading_is_gives_expected_points(
-    groundtruth_las: laspy.LasData, reader: laspy.LasReader, iter_size: int
-):
-    """Checks that the points read by the reader are the same as groundtruth points."""
-    assert groundtruth_las.point_format == reader.header.point_format
-    for i, points in enumerate(reader.chunk_iterator(iter_size)):
-        expected_points = groundtruth_las.points[i * iter_size : (i + 1) * iter_size]
-        for dim_name in points.array.dtype.names:
-            assert np.allclose(
-                expected_points[dim_name], points[dim_name]
-            ), f"{dim_name} not equal"
-
 
 @pytest.mark.parametrize("backend", laspy.LazBackend.detect_available() + (None,))
 def test_chunked_dimension_modification(file_path, backend):
@@ -111,4 +107,4 @@ def test_chunked_dimension_modification(file_path, backend):
     ground_truth_las.x += 10.0
 
     reader = laspy.open(mem_dest, laz_backend=backend)
-    check_chunked_reading_is_gives_expected_points(ground_truth_las, reader, 42)
+    check_chunked_reading_gives_expected_points(ground_truth_las, reader, 42)

--- a/tests/test_non_seekable.py
+++ b/tests/test_non_seekable.py
@@ -1,0 +1,76 @@
+import pytest
+import laspy
+from .conftest import laz_file_path, las_file_path, LAZ_1_4_WITH_EVLRS_FILE_PATH, LAS_1_4_WITH_EVLRS_FILE_PATH
+from .test_chunk_read_write import check_chunked_reading_gives_expected_points
+from laspy import VLR
+
+class NonSeekableStream:
+    """
+    Fake non stream / file object which simulates a file object
+    on which we cannot seek
+    """
+    def __init__(self, inner):
+        self.inner = inner
+
+    def read(self, n):
+        return self.inner.read(n)
+
+    def seekable(self):
+        return False
+
+EXPECTED_EVLRS = [
+    VLR(
+        user_id="pylastest",
+        record_id=42,
+        description='just a test evlr',
+        record_data=b'Test 1 2 ... 1 2',
+    )
+]
+
+@pytest.mark.skipif(
+    not laspy.LazBackend.Lazrs.is_available(),
+    reason="None seekable laz is only supported by lazrs"
+)
+def test_laz_reading_non_seekable_stream(laz_file_path):
+    with open(laz_file_path, mode="rb") as f:
+        stream = NonSeekableStream(f)
+        laspy.read(stream, closefd=False)
+
+def test_las_reading_non_seekable_stream(las_file_path):
+    with open(las_file_path, mode="rb") as f:
+        stream = NonSeekableStream(f)
+        laspy.read(stream, closefd=False)
+
+@pytest.mark.skipif(
+    not laspy.LazBackend.Lazrs.is_available(),
+    reason="None seekable laz is only supported by lazrs"
+)
+def test_laz_with_evlr_reading_non_seekable_stream():
+    with open(LAZ_1_4_WITH_EVLRS_FILE_PATH, mode="rb") as f:
+        stream = NonSeekableStream(f)
+        las = laspy.read(stream, closefd=False)
+        assert las.evlrs == EXPECTED_EVLRS
+
+
+def test_las_with_evlr_reading_non_seekable_stream(las_file_path):
+    with open(LAS_1_4_WITH_EVLRS_FILE_PATH, mode="rb") as f:
+        stream = NonSeekableStream(f)
+        las = laspy.read(stream, closefd=False)
+        assert las.evlrs == EXPECTED_EVLRS
+
+
+def test_non_seekable_chunked_las_reading(las_file_path):
+    ground_truth = laspy.read(las_file_path)
+    with open(las_file_path, mode='rb') as raw_file:
+        las_reader = laspy.open(NonSeekableStream(raw_file), closefd=False)
+        check_chunked_reading_gives_expected_points(ground_truth, las_reader, iter_size=130)
+
+@pytest.mark.skipif(
+    not laspy.LazBackend.Lazrs.is_available(),
+    reason="None seekable laz is only supported by lazrs"
+)
+def test_non_seekable_chunked_laz_reading(laz_file_path):
+    ground_truth = laspy.read(laz_file_path)
+    with open(laz_file_path, mode='rb') as raw_file:
+        las_reader = laspy.open(NonSeekableStream(raw_file), closefd=False)
+        check_chunked_reading_gives_expected_points(ground_truth, las_reader, iter_size=130)

--- a/tests/test_reading_1_2.py
+++ b/tests/test_reading_1_2.py
@@ -226,3 +226,4 @@ def test_seek_las(las_file_path):
 def test_seek_laz(laz_file_path, laz_backend):
     with laspy.open(laz_file_path, laz_backend=laz_backend) as reader:
         check_seeking_works(reader)
+


### PR DESCRIPTION
This makes it so that we can read LAS/LAS files from non seekable sources.

The `LasHeader.read_from` method now prefetches all bytes corresponding to
head + VLR and two call to `sourc.read`.

The support is not 100% on par with seekable stream but should be enough.
- non-seekable LAS files should work fine
- non-seekable LAZ files needs lazrs (and for these, Parallel decompression
  strategy cannot be used, as we can't seek to fetch the chunk table)
- non-seekable LAZ with EVLR are not supported with non seekable streams.

Fixes #218 

TODO:
- [x] Release lazrs version with needed fix
- [x] Add chunk reading tests ?
- [x] Make sure a 1.4 LAZ is in the tests