### PR TITLE
Fix parse_crs

### DIFF
--- a/laspy/header.py
+++ b/laspy/header.py
@@ -795,7 +795,9 @@ class LasHeader:
 
         for rec in geo_vlr:
             if isinstance(rec, (WktCoordinateSystemVlr, GeoKeyDirectoryVlr)):
-                return rec.parse_crs()
+                crs = rec.parse_crs()
+                if crs is not None:
+                    return crs
 
         return None
 

--- a/laspy/vlrs/vlrlist.py
+++ b/laspy/vlrs/vlrlist.py
@@ -63,18 +63,12 @@ class VLRList(list):
             a list of vlrs matching the user_id and records_ids
 
         """
-        if user_id != "" and record_ids != (None,):
-            return [
-                vlr
-                for vlr in self
-                if vlr.user_id == user_id and vlr.record_id in record_ids
-            ]
-        else:
-            return [
-                vlr
-                for vlr in self
-                if vlr.user_id == user_id or vlr.record_id in record_ids
-            ]
+        return [
+            vlr
+            for vlr in self
+            if (user_id == "" or vlr.user_id == user_id)
+            and (record_ids == (None,) or vlr.record_id in record_ids)
+        ]
 
     def get(self, vlr_type: str) -> List[IKnownVLR]:
         """Returns the list of vlrs of the requested type


### PR DESCRIPTION
I was working with a las file that contains both a `GeoKeyDirectoryVlr` and a `WktCoordinateSystemVlr`, but the first one was empty (it is LAS 1.4 generated by lastools, not really sure why that was the case). In any case, `parse_crs` was yielding me None as the crs while lasinfo got me the right one.

That led me to investigate the problem and I ended up finding two issues. One was that the `parse_crs` method was returning the value parsed from the first VLR available and, in my case, that resulted in `None`. The second was that `get_by_id` wasn't returning all the possible VLRs with the given `user_id` (LASF_Projection). I hope this PR fixes both problems.