### PR TITLE
Fix crash accessing LasReader.point_source.source for empty file

### DIFF
--- a/laspy/lasreader.py
+++ b/laspy/lasreader.py
@@ -407,6 +407,10 @@ class EmptyPointReader(IPointReader):
     Used to make sure we handle empty LAS files in a robust way.
     """
 
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.source = io.BytesIO()
+
     def read_n_points(self, n: int) -> bytearray:
         return bytearray()
 


### PR DESCRIPTION
When I try to open a file with zero points I get

```
  File "../lib/python3.9/site-packages/laspy/lib.py", line 187, in read_las
    return reader.read()
  File ".../lib/python3.9/site-packages/laspy/lasreader.py", line 119, in read
    source = self.point_source.source
AttributeError: 'EmptyPointReader' object has no attribute 'source'
```

This fixes it