### PR TITLE
LasReader now tries to read evlr when initialized

### DIFF
--- a/tests/test_reading_1_4.py
+++ b/tests/test_reading_1_4.py
@@ -1,4 +1,5 @@
 import pytest
+import os
 
 import laspy
 from tests.test_common import test1_4_las
@@ -77,3 +78,14 @@ def test_gps_time(file):
 def test_scanner_channel(file):
     assert file.scanner_channel.max() == 0
     assert file.scanner_channel.min() == 0
+
+def test_we_read_evlrs_when_simply_opening():
+    file_with_evlrs = os.path.dirname(__file__) + "/data/1_4_w_evlr.las"
+    expected_evlrs = laspy.VLR(
+            user_id="pylastest",
+            record_id=42,
+            description="just a test evlr",
+            record_data=b'Test 1 2 ... 1 2',
+        )
+    with laspy.open(file_with_evlrs) as reader:
+        assert reader.evlrs == [expected_evlrs]


### PR DESCRIPTION
`LasReader` nows reads evlrs when the file is openned so that they are accessible when doing `laspy.open`.
