### PR TITLE
Evlrs in header

### DIFF
--- a/laspy/copc.py
+++ b/laspy/copc.py
@@ -709,7 +709,7 @@ class CopcReader:
                The level of detail (LOD).
 
                - If None, all LOD are going to be considered
-               - If it is an int, only points that that are of the requested LOD
+               - If it is an int, only points that are of the requested LOD
                  will be returned.
                - If it is a range, points for which the LOD is within the range
                  will be returned

--- a/laspy/header.py
+++ b/laspy/header.py
@@ -819,6 +819,9 @@ class LasHeader:
 
         geo_vlr = self._vlrs.get_by_id("LASF_Projection")
 
+        if self.evlrs is not None:
+            geo_vlr.extend(self.evlrs.get_by_id("LASF_Projection"))
+
         for rec in geo_vlr:
             if isinstance(rec, (WktCoordinateSystemVlr, GeoKeyDirectoryVlr)):
                 crs = rec.parse_crs()

--- a/laspy/lasdata.py
+++ b/laspy/lasdata.py
@@ -59,10 +59,6 @@ class LasData:
         self.__dict__["_points"] = points
         self.points: record.ScaleAwarePointRecord
         self.header: LasHeader = header
-        if header.version.minor >= 4:
-            self.evlrs: Optional[VLRList] = VLRList()
-        else:
-            self.evlrs: Optional[VLRList] = None
 
     @property
     def point_format(self) -> PointFormat:
@@ -112,6 +108,14 @@ class LasData:
     @vlrs.setter
     def vlrs(self, vlrs) -> None:
         self.header.vlrs = vlrs
+
+    @property
+    def evlrs(self) -> Optional[VLRList]:
+        return self.header.evlrs
+
+    @evlrs.setter
+    def evlrs(self, evlrs: VLRList) -> None:
+        self.header.evlrs = evlrs
 
     def add_extra_dim(self, params: ExtraBytesParams) -> None:
         """Adds a new extra dimension to the point record


### PR DESCRIPTION
Moves storage of evlrs into the LasHeader class.

Fix LasHeader.parse_crs to now take into account crs evrs.

Fixes #230 