### PR TITLE
record.py:from_buffer, adjust count size to prevent exception

### DIFF
--- a/laspy/__init__.py
+++ b/laspy/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.3.0"
+__version__ = "2.3.0-TAL"
 
 import logging
 

--- a/laspy/__init__.py
+++ b/laspy/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.3.0-TAL"
+__version__ = "2.3.0"
 
 import logging
 

--- a/laspy/point/record.py
+++ b/laspy/point/record.py
@@ -122,6 +122,10 @@ class PackedPointRecord:
 
     @classmethod
     def from_buffer(cls, buffer, point_format, count=-1, offset=0):
+        # TODO: adjust count size to prevent exception
+        # - Jaeyoon Jeong(diem389@gmail.com), 2020-10-06
+        item_size = point_format.size
+        count = len(buffer) // item_size
         points_dtype = point_format.dtype()
         data = np.frombuffer(buffer, dtype=points_dtype, offset=offset, count=count)
 


### PR DESCRIPTION
In some case, from_buffer makes some exception. So I adjusted this provisionally. Could you anyone review this issue? I think there would be a better way to handle this problem.I also attach the sample las file that makes the error. 

[error.zip](https://github.com/laspy/laspy/files/10049656/error.zip)
