### PR TITLE
Removed unnecessary print statements

### DIFF
--- a/laspy/compression.py
+++ b/laspy/compression.py
@@ -255,7 +255,6 @@ class DecompressionSelection(enum.IntFlag):
         for variant in DecompressionSelection:
             lazrs_selection |= variant_mapping[variant] if self.is_set(variant) else 0
 
-        print(lazrs_selection)
         return lazrs.DecompressionSelection(lazrs_selection)
 
     def to_laszip(self) -> int:

--- a/laspy/copc.py
+++ b/laspy/copc.py
@@ -821,7 +821,6 @@ class CopcReader:
             num_points * self.header.point_format.size, dtype=np.uint8
         )
 
-        print(self.decompression_selection)
         lazrs.decompress_points_with_chunk_table(
             compressed_bytes,
             self.laszip_vlr.record_data,


### PR DESCRIPTION
# Description

This merge request removes `print` statements that have probably been left out after a development in the `copc.py` and `compression.py` files.

# Motivation

Those `print` statements are probably unintended, and could potentially break *doctests*