### PR TITLE
Close input/output stream if on opening fail

### DIFF
--- a/laspy/lib.py
+++ b/laspy/lib.py
@@ -143,13 +143,18 @@ def open_las(
             stream = io.BytesIO(source)
         else:
             stream = source
-        return LasReader(
-            stream,
-            closefd=closefd,
-            laz_backend=laz_backend,
-            read_evlrs=read_evlrs,
-            decompression_selection=decompression_selection,
-        )
+        try:
+            return LasReader(
+                stream,
+                closefd=closefd,
+                laz_backend=laz_backend,
+                read_evlrs=read_evlrs,
+                decompression_selection=decompression_selection,
+            )
+        except:
+            if closefd:
+                stream.close()
+            raise
     elif mode == "w":
         if header is None:
             raise ValueError("A header is needed when opening a file for writing")
@@ -164,14 +169,19 @@ def open_las(
             assert source.seekable()
             stream = source
 
-        return LasWriter(
-            stream,
-            header=header,
-            do_compress=do_compress,
-            laz_backend=laz_backend,
-            closefd=closefd,
-            encoding_errors=encoding_errors,
-        )
+        try:
+            return LasWriter(
+                stream,
+                header=header,
+                do_compress=do_compress,
+                laz_backend=laz_backend,
+                closefd=closefd,
+                encoding_errors=encoding_errors,
+            )
+        except:
+            if closefd:
+                stream.close()
+            raise
     elif mode == "a":
         if isinstance(source, (str, Path)):
             stream = open(source, mode="rb+", closefd=closefd)
@@ -179,13 +189,18 @@ def open_las(
             stream = io.BytesIO(source)
         else:
             stream = source
-        return LasAppender(
-            stream,
-            closefd=closefd,
-            laz_backend=laz_backend,
-            encoding_errors=encoding_errors,
-        )
 
+        try:
+            return LasAppender(
+                stream,
+                closefd=closefd,
+                laz_backend=laz_backend,
+                encoding_errors=encoding_errors,
+            )
+        except:
+            if closefd:
+                stream.close()
+            raise
     else:
         raise ValueError(f"Unknown mode '{mode}'")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,9 @@ class NonSeekableStream:
     def seekable(self):
         return False
 
+    def close(self):
+        pass
+
 
 @pytest.fixture()
 def simple_las_path():


### PR DESCRIPTION
The `laspy.open` (open_las) was meant to be used with a `with statement` (`with laspy.open(....) as f:...`) so that the input/ouput would properly be closed in case of  and exception being raised.

However, if the exception got raised within the
`__init__` function of either of LasReader, LasWriter, LasAppender then the object in `as name` would not have been constructed thus the `__exit__` function of the LasReader/LasWriter/LasAppender cannot be run, meaning the stream would not be closed.

This commit fixes that by catching, closing file then rethrowing in the open_las function

Fixes #264 