### PR TITLE
Check  geokey value before assuming its an EPSG

### DIFF
--- a/laspy/header.py
+++ b/laspy/header.py
@@ -810,6 +810,9 @@ class LasHeader:
         """
         Method to parse OGC WKT or GeoTiff VLR keys into a pyproj CRS object
 
+        Returns None if no CRS VLR is present, or if the CRS specified
+        in the VLRS is not understood.
+
         .. warning::
             This requires `pyproj`.
         """

--- a/laspy/vlrs/known.py
+++ b/laspy/vlrs/known.py
@@ -516,9 +516,15 @@ class GeoKeyDirectoryVlr(BaseKnownVLR):
         projected_cs = None
         for key in self.geo_keys:
             if key.id == ProjectedCSTypeGeoKey.id:
-                projected_cs = pyproj.CRS.from_epsg(key.value_offset)
+                if 1024 <= key.value_offset <= 32766:
+                    # http://docs.opengeospatial.org/is/19-008r4/19-008r4.html#_requirements_class_projectedcrsgeokey
+                    # "ProjectedCRSGeoKey values in the range 1024-32766 SHALL be EPSG Projected CRS Codes"
+                    projected_cs = pyproj.CRS.from_epsg(key.value_offset)
             elif key.id == GeographicTypeGeoKey.id:
-                geographic_cs = pyproj.CRS.from_epsg(key.value_offset)
+                # http://docs.opengeospatial.org/is/19-008r4/19-008r4.html#_requirements_class_geodeticcrsgeokey
+                # GeodeticCRSGeoKey values in the range 1024-32766 SHALL be EPSG geographic 2D or geocentric CRS codes
+                if 1024 <= key.value_offset <= 32766:
+                    geographic_cs = pyproj.CRS.from_epsg(key.value_offset)
 
         # Projected Coordinate Systems take precedence since,
         # if they are present, the Geographic CS is probably


### PR DESCRIPTION
In the geotiff specification, the value (contained in value_offset) for the keys ProjectedCRSGeoKey and GeodeticCRSGeoKey had different meaning depending on the range in which the value was.

We however assumed the value was always an EPSG code, leading to errors because we would then ask pyproj to get the proj from the epsg value, which was not one.

This commit fixes it by adding a check on the range written in the spec.

Fixes #261