### PR TITLE
add missing super().__init__() in CopcHierarchyVlr

### DIFF
--- a/laspy/copc.py
+++ b/laspy/copc.py
@@ -309,6 +309,7 @@ class CopcHierarchyVlr(BaseKnownVLR):
     """
 
     def __init__(self) -> None:
+        super().__init__()
         self.data: bytes = b""
         self.root_page = HierarchyPage()
 


### PR DESCRIPTION
Without this, on a copc file with a crs vlr, calling `parse_crs()` would fail with an error like this:

```
File "laspy/header.py", line 820, in parse_crs
    geo_vlr.extend(self.evlrs.get_by_id("LASF_Projection"))
File "laspy/vlrs/vlrlist.py", line 66, in get_by_id
    return [
File "laspy/vlrs/vlrlist.py", line 69, in <listcomp>
    if (user_id == "" or vlr.user_id == user_id)
File "laspy/vlrs/vlr.py", line 37, in user_id
    return self._user_id
AttributeError: 'CopcHierarchyVlr' object has no attribute '_user_id'
```
I can add a test if you prefer, just let me know.