### PR TITLE
Change np.bool to bool

### DIFF
--- a/laspy/point/dims.py
+++ b/laspy/point/dims.py
@@ -646,7 +646,7 @@ class SubFieldView(ArrayView):
     def _do_comparison(self, value, comp):
         if isinstance(value, (int, type(self.array.dtype))):
             if value > self.max_value_allowed:
-                return np.zeros_like(self.array, np.bool)
+                return np.zeros_like(self.array, bool)
         return comp(self.array & self.bit_mask, value << self.lsb)
 
     def __array__(self, *args, **kwargs):


### PR DESCRIPTION
`np.bool` was deprecated in numpy 1.20 (Jan 30, 2021), and removed in numpy 1.24 (Dec 18, 2022)

When using np.bool in numpy 1.24, we get the error:
```
AttributeError: module 'numpy' has no attribute 'bool'.
`np.bool` was a deprecated alias for the builtin `bool`. 
To avoid this error in existing code, use `bool` by itself. 
Doing this will not modify any behavior and is safe. 
If you specifically wanted the numpy scalar type, use `np.bool_` here.
```