### PR TITLE
Fix: don't reset custom creation_date

### DIFF
--- a/laspy/header.py
+++ b/laspy/header.py
@@ -217,7 +217,7 @@ class LasHeader:
         #: Initialized to 'laspy'
         self.generating_software: Union[str, bytes] = DEFAULT_GENERATING_SOFTWARE
         self._point_format: PointFormat = point_format
-        #: Day the file was created, initialized to date.today()
+        #: Day the file was created, initialized to date.today
         self.creation_date: Optional[date] = date.today()
         #: The number of points in the file
         self.point_count: int = 0
@@ -466,8 +466,6 @@ class LasHeader:
         self.point_format = point_format
 
     def partial_reset(self) -> None:
-        self.creation_date = date.today()
-
         f64info = np.finfo(np.float64)
         self.maxs = np.ones(3, dtype=np.float64) * f64info.min
         self.mins = np.ones(3, dtype=np.float64) * f64info.max


### PR DESCRIPTION
LasHeader.partial_reset used to always reset the
creation_date to date.today(),
meaning users could not set a custom date.

This makes it so that if the header already has a date where becayse manually set by the user or because it is the value read from a file, it won't get reset

Writing a file from a newly created header
will still write date.today to the file on disk.

Fixes #280 