### PR TITLE
Remove support for Python 3.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
         laz-backend: [ None, lazrs, laszip ]
 
     steps:
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install black & isort
         run: |

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ sphinx:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.8
   install:
     - method: pip
       path: .

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Laspy is a python library for reading, modifying and creating LAS LiDAR
 files.
 
-Laspy is compatible with Python  3.7+.
+Laspy is compatible with Python  3.8+.
 
 ## Features
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,7 +1,7 @@
 import nox
 
 
-@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11"])
+@nox.session(python=["3.8", "3.9", "3.10", "3.11"])
 @nox.parametrize("laz_backend", [None, "lazrs", "laszip"])
 def tests(session, laz_backend):
     session.install("pytest")

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     long_description=readme,
     long_description_content_type="text/markdown",
     packages=find_packages(exclude=("tests",)),
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=["numpy"],
     extras_require={
         "dev": [


### PR DESCRIPTION
Python 3.7 support ended on 27 Jun 2023.

We can remove support for this version of Python
from the CI and other various things.