### PR TITLE
Add guards against writing more that max_point_count points

### DIFF
--- a/laspy/lasappender.py
+++ b/laspy/lasappender.py
@@ -70,6 +70,14 @@ class LasAppender:
         if points.point_format != self.header.point_format:
             raise LaspyException("Point formats do not match")
 
+        if self.header.max_point_count() - self.header.point_count < len(points):
+            raise LaspyException(
+                "Cannot write {} points as it would exceed the maximum number of points the file"
+                "can store. Current point count: {}, max point count: {}".format(
+                    len(points), self.header.point_count, self.header.max_point_count()
+                )
+            )
+
         self.points_appender.append_points(points)
         self.header.grow(points)
 

--- a/laspy/laswriter.py
+++ b/laspy/laswriter.py
@@ -122,6 +122,14 @@ class LasWriter:
         if points.point_format != self.header.point_format:
             raise LaspyException("Incompatible point formats")
 
+        if self.header.max_point_count() - self.header.point_count < len(points):
+            raise LaspyException(
+                "Cannot write {} points as it would exceed the maximum number of points the file"
+                "can store. Current point count: {}, max point count: {}".format(
+                    len(points), self.header.point_count, self.header.max_point_count()
+                )
+            )
+
         self.header.grow(points)
         self.point_writer.write_points(points)
 


### PR DESCRIPTION
LasHeader.write_to did a check on the point_count if it exceeded the maximum allowed value.

However that check is a bit late, so another check was added in write_points and append_points.

prevents #285 