### PR TITLE
CLI: add filter command

### DIFF
--- a/laspy/cli/core.py
+++ b/laspy/cli/core.py
@@ -352,6 +352,7 @@ def _copy_files(
 
         if num_fails == len(input_files):
             overall_progress.update(overall_task, description=f"[red] Failed all tasks")
+            raise typer.Abort()
         elif num_fails == 0:
             overall_progress.update(
                 overall_task,

--- a/noxfile.py
+++ b/noxfile.py
@@ -15,7 +15,7 @@ def tests(session, laz_backend):
 @nox.session
 @nox.parametrize(
     "optional_dependencies",
-    [None, "laszip", "lazrs", "pyproj", "requests,lazrs", "cli"],
+    [None, "laszip", "lazrs", "pyproj", "requests,lazrs", "cli,lazrs"],
 )
 def coverage(session, optional_dependencies):
     if optional_dependencies is None:

--- a/noxfile.py
+++ b/noxfile.py
@@ -14,7 +14,8 @@ def tests(session, laz_backend):
 
 @nox.session
 @nox.parametrize(
-    "optional_dependencies", [None, "laszip", "lazrs", "pyproj", "requests,lazrs"]
+    "optional_dependencies",
+    [None, "laszip", "lazrs", "pyproj", "requests,lazrs", "cli"],
 )
 def coverage(session, optional_dependencies):
     if optional_dependencies is None:

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+def skip_if_cli_deps_are_not_installed():
+    try:
+        from laspy.cli.core import app
+    except ModuleNotFoundError:
+        pytest.skip("skipping cli test (deps not installed)", allow_module_level=True)

--- a/tests/cli/test_compress_decompress.py
+++ b/tests/cli/test_compress_decompress.py
@@ -1,0 +1,126 @@
+import numpy as np
+import pytest
+
+import laspy
+
+from ..test_common import skip_if_no_laz_backend
+from . import skip_if_cli_deps_are_not_installed
+
+skip_if_cli_deps_are_not_installed()
+
+pytestmark = skip_if_no_laz_backend
+
+from typer.testing import CliRunner
+
+runner = CliRunner()
+from laspy.cli.core import app
+
+
+def test_cli_compress(tmp_path):
+    input_path = "tests/data/simple.las"
+    output_path = tmp_path / "simple.laz"
+    result = runner.invoke(
+        app,
+        [
+            "compress",
+            input_path,
+            "--output-path",
+            str(output_path),
+        ],
+    )
+    assert result.exit_code == 0, "{}".format(result.stdout)
+
+    with laspy.open(output_path) as f:
+        assert f.header.are_points_compressed is True
+
+    original_las = laspy.read(input_path)
+    compressed_las = laspy.read(output_path)
+
+    assert original_las.point_format == compressed_las.point_format
+    assert original_las.vlrs == compressed_las.vlrs
+    assert np.all(original_las.points == compressed_las.points)
+
+
+def test_cli_compress_cannot_overwrite(tmp_path):
+    input_path = "tests/data/simple.las"
+    output_path = tmp_path / "simple.laz"
+    result = runner.invoke(
+        app,
+        [
+            "compress",
+            input_path,
+            "--output-path",
+            input_path,
+        ],
+    )
+    assert result.exit_code != 0, "{}".format(result.stdout)
+
+
+def test_cli_compress_non_existing_file(tmp_path):
+    input_path = "tests/data/i-do-not-exist.las"
+    output_path = tmp_path / "i-do-not-exist.laz"
+    result = runner.invoke(
+        app,
+        [
+            "compress",
+            input_path,
+            "--output-path",
+            str(output_path),
+        ],
+    )
+    assert result.exit_code != 0, "{}".format(result.stdout)
+
+
+def test_cli_decompress(tmp_path):
+    input_path = "tests/data/simple.laz"
+    output_path = tmp_path / "simple.las"
+    result = runner.invoke(
+        app,
+        [
+            "decompress",
+            input_path,
+            "--output-path",
+            str(output_path),
+        ],
+    )
+    assert result.exit_code == 0, "{}".format(result.stdout)
+
+    with laspy.open(output_path) as f:
+        assert f.header.are_points_compressed is False
+
+    original_las = laspy.read(input_path)
+    compressed_las = laspy.read(output_path)
+
+    assert original_las.point_format == compressed_las.point_format
+    assert original_las.vlrs == compressed_las.vlrs
+    assert np.all(original_las.points == compressed_las.points)
+
+
+def test_cli_decompress_cannot_overwrite(tmp_path):
+    input_path = "tests/data/simple.laz"
+    output_path = tmp_path / "simple.las"
+    result = runner.invoke(
+        app,
+        [
+            "decompress",
+            input_path,
+            "--output-path",
+            input_path,
+        ],
+    )
+    assert result.exit_code != 0, "{}".format(result.stdout)
+
+
+def test_cli_decompress_non_existing_file(tmp_path):
+    input_path = "tests/data/i-do-not-exist.laz"
+    output_path = tmp_path / "i-do-not-exist.las"
+    result = runner.invoke(
+        app,
+        [
+            "decompress",
+            input_path,
+            "--output-path",
+            str(output_path),
+        ],
+    )
+    assert result.exit_code != 0, "{}".format(result.stdout)

--- a/tests/cli/test_filter.py
+++ b/tests/cli/test_filter.py
@@ -1,0 +1,407 @@
+import numpy as np
+import pytest
+
+import laspy
+
+from . import skip_if_cli_deps_are_not_installed
+
+skip_if_cli_deps_are_not_installed()
+
+from typer.testing import CliRunner
+
+from laspy.cli.core import (
+    BinaryFilteringExpression,
+    Comparator,
+    Condition,
+    FilteringAction,
+    FilteringExpression,
+    FilteringExpressionKind,
+    NegatedFilteringExpression,
+    Token,
+    app,
+    parse_float_or_int,
+    parse_list_of_numbers,
+    tokenize,
+)
+
+runner = CliRunner()
+
+
+def test_parse_float_or_number():
+    value = parse_float_or_int("10")
+    assert type(value) == int
+    assert value == 10
+
+    value = parse_float_or_int(" 17 ")
+    assert type(value) == int
+    assert value == 17
+
+    value = parse_float_or_int("0.3")
+    assert type(value) == float
+    assert value == 0.3
+
+    value = parse_float_or_int(" 0.889 ")
+    assert type(value) == float
+    assert value == 0.889
+
+    with pytest.raises(ValueError):
+        _ = parse_float_or_int("238a")
+
+
+def test_parse_list_of_numbers():
+    value = parse_list_of_numbers("[1, 2, 3]")
+    assert value == [1, 2, 3]
+
+    value = parse_list_of_numbers("(4, 5, 6)")
+    assert value == [4, 5, 6]
+
+    with pytest.raises(ValueError):
+        _ = parse_list_of_numbers("238")
+
+    with pytest.raises(ValueError):
+        _ = parse_list_of_numbers("[238, 1")
+
+    with pytest.raises(ValueError):
+        _ = parse_list_of_numbers("38, 1]")
+
+
+def test_tokenize():
+    tokens = tokenize("not classification == 2")
+
+    Kind = Token.Kind
+    expected = [
+        Token(Kind.Not, "not"),
+        Token(Kind.LiteralStr, "classification"),
+        Token(Kind.EqEq, "=="),
+        Token(Kind.LiteralStr, "2"),
+    ]
+    assert tokens == expected
+
+
+def test_parse_valid_filter_action():
+    action = FilteringAction.parse_string("intensity >= 128")
+
+    expected = FilteringAction("intensity", Comparator.GreaterOrEqual, "128")
+    assert action == expected
+
+
+def test_parse_valid_filter_action_in():
+    action = FilteringAction.parse_string("intensity in [128, 129, 130]")
+
+    expected = FilteringAction("intensity", Comparator.In, "[128, 129, 130]")
+    assert action == expected
+
+
+def test_parse_invalid_filter_action_invalid_operator():
+    with pytest.raises(ValueError):
+        _ = FilteringAction.parse_string("point_source_id <> 128")
+
+
+def test_parse_invalid_filter_action_no_operator():
+    """This one show that our simplistic parsing catches some error late"""
+    with pytest.raises(ValueError):
+        _ = FilteringAction.parse_string("point_source_id 128")
+
+
+def test_parse_filtering_expression():
+    parsed_expr = FilteringExpression.parse_string(
+        "classification == 2 or classification == 3 and x > 10.0"
+    )
+
+    """
+                            ┌────┐
+                            │ or │
+                            └▲─▲─┘
+                             │ │
+                             │ │
+                             │ │
+       ┌─────────────────────┤ │
+       │ classification == 2 │ │
+       └─────────────────────┘ └───────┬─────┐
+                                       │ and │
+                                       └─▲──▲┘
+                                         │  │
+                  ┌─────────────────────┬┘  └─┬──────────┐
+                  │ classification == 3 │     │ x > 10.0 │
+                  └─────────────────────┘     └──────────┘
+    """
+
+    expected_expr = FilteringExpression(
+        kind=FilteringExpressionKind.Binary,
+        data=BinaryFilteringExpression(
+            condition=Condition.Or,
+            lhs=FilteringExpression(
+                kind=FilteringExpressionKind.Action,
+                data=FilteringAction(
+                    field_name="classification",
+                    comparator=Comparator.Equality,
+                    value="2",
+                ),
+            ),
+            rhs=FilteringExpression(
+                kind=FilteringExpressionKind.Binary,
+                data=BinaryFilteringExpression(
+                    condition=Condition.And,
+                    lhs=FilteringExpression(
+                        kind=FilteringExpressionKind.Action,
+                        data=FilteringAction(
+                            field_name="classification",
+                            comparator=Comparator.Equality,
+                            value="3",
+                        ),
+                    ),
+                    rhs=FilteringExpression(
+                        kind=FilteringExpressionKind.Action,
+                        data=FilteringAction(
+                            field_name="x",
+                            comparator=Comparator.GreaterThan,
+                            value="10.0",
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    assert parsed_expr == expected_expr
+
+
+def test_parse_filtering_expression_not():
+    parsed_expr = FilteringExpression.parse_string("not classification == 2")
+
+    expected_expr = FilteringExpression(
+        kind=FilteringExpressionKind.Negated,
+        data=NegatedFilteringExpression(
+            expr=FilteringExpression(
+                kind=FilteringExpressionKind.Action,
+                data=FilteringAction(
+                    field_name="classification",
+                    comparator=Comparator.Equality,
+                    value="2",
+                ),
+            ),
+        ),
+    )
+
+    assert parsed_expr == expected_expr
+
+
+def test_parse_filtering_expression_2():
+    parsed_expr = FilteringExpression.parse_string(
+        "(classification == 2 or classification == 3) and x > 10.0"
+    )
+
+    """
+                                    ┌─────┐
+                                    │ And │
+                                    └─▲─▲─┘
+                                      │ │
+                                      │ │
+                         ┌────┬───────┘ │
+                  ┌─────►│ or │         └────────────────┬──────────┐
+                  │      └───▲┘                          │ x > 10.0 │
+                  │          │                           └──────────┘
+   ┌──────────────┴───────┐ ┌┴────────────────────┐
+   │ classification == 2  │ │ classification == 3 │
+   └──────────────────────┘ └─────────────────────┘
+    """
+
+    expected_expr = FilteringExpression(
+        kind=FilteringExpressionKind.Binary,
+        data=BinaryFilteringExpression(
+            condition=Condition.And,
+            lhs=FilteringExpression(
+                kind=FilteringExpressionKind.Binary,
+                data=BinaryFilteringExpression(
+                    condition=Condition.Or,
+                    lhs=FilteringExpression(
+                        kind=FilteringExpressionKind.Action,
+                        data=FilteringAction(
+                            field_name="classification",
+                            comparator=Comparator.Equality,
+                            value="2",
+                        ),
+                    ),
+                    rhs=FilteringExpression(
+                        kind=FilteringExpressionKind.Action,
+                        data=FilteringAction(
+                            field_name="classification",
+                            comparator=Comparator.Equality,
+                            value="3",
+                        ),
+                    ),
+                ),
+            ),
+            rhs=FilteringExpression(
+                kind=FilteringExpressionKind.Action,
+                data=FilteringAction(
+                    field_name="x",
+                    comparator=Comparator.GreaterThan,
+                    value="10.0",
+                ),
+            ),
+        ),
+    )
+
+    assert parsed_expr == expected_expr
+
+
+def test_parse_filtering_expression_2_pdal_style():
+    parsed_expr = FilteringExpression.parse_string(
+        "(classification == 2 || classification == 3) && x > 10.0"
+    )
+
+    expected_expr = FilteringExpression(
+        kind=FilteringExpressionKind.Binary,
+        data=BinaryFilteringExpression(
+            condition=Condition.And,
+            lhs=FilteringExpression(
+                kind=FilteringExpressionKind.Binary,
+                data=BinaryFilteringExpression(
+                    condition=Condition.Or,
+                    lhs=FilteringExpression(
+                        kind=FilteringExpressionKind.Action,
+                        data=FilteringAction(
+                            field_name="classification",
+                            comparator=Comparator.Equality,
+                            value="2",
+                        ),
+                    ),
+                    rhs=FilteringExpression(
+                        kind=FilteringExpressionKind.Action,
+                        data=FilteringAction(
+                            field_name="classification",
+                            comparator=Comparator.Equality,
+                            value="3",
+                        ),
+                    ),
+                ),
+            ),
+            rhs=FilteringExpression(
+                kind=FilteringExpressionKind.Action,
+                data=FilteringAction(
+                    field_name="x",
+                    comparator=Comparator.GreaterThan,
+                    value="10.0",
+                ),
+            ),
+        ),
+    )
+
+    assert parsed_expr == expected_expr
+
+
+def test_apply_filter_expression():
+    parsed_expr = FilteringExpression.parse_string(
+        "classification == 2 or classification == 3 and x > 10.0"
+    )
+
+    points = laspy.ScaleAwarePointRecord.zeros(
+        3,
+        point_format=laspy.PointFormat(3),
+        scales=np.array([1.0, 1.0, 1.0]),
+        offsets=np.array([1.0, 1.0, 1.0]),
+    )
+    points["classification"] = [1, 2, 3]
+    points["x"] = [1.0, 5.0, 11.0]
+
+    result = parsed_expr.apply(points)
+
+    expected = np.array([False, True, True])
+    assert np.all(result == expected)
+
+
+def test_apply_filter_expression_2():
+    parsed_expr = FilteringExpression.parse_string(
+        "(classification == 2 or classification == 3) and x > 10.0"
+    )
+
+    points = laspy.ScaleAwarePointRecord.zeros(
+        3,
+        point_format=laspy.PointFormat(3),
+        scales=np.array([1.0, 1.0, 1.0]),
+        offsets=np.array([1.0, 1.0, 1.0]),
+    )
+    points["classification"] = [1, 2, 3]
+    points["x"] = [1.0, 5.0, 11.0]
+
+    result = parsed_expr.apply(points)
+
+    expected = np.array([False, False, True])
+    assert np.all(result == expected)
+
+
+def test_cli_filtering_classification_eq_2(tmp_path):
+    path = tmp_path / "simple_cls_2.las"
+    result = runner.invoke(
+        app, ["filter", "tests/data/simple.las", str(path), "classification == 2"]
+    )
+    assert result.exit_code == 0
+
+    las = laspy.read(path)
+    assert np.all(las.classification == 2)
+
+
+def test_cli_filtering_classification_ne_2(tmp_path):
+    path = tmp_path / "simple_cls_2.las"
+    result = runner.invoke(
+        app, ["filter", "tests/data/simple.las", str(path), "classification != 2"]
+    )
+    assert result.exit_code == 0
+
+    las = laspy.read(path)
+    assert np.all(las.classification != 2)
+
+
+def test_cli_filtering_classification_in(tmp_path):
+    path = tmp_path / "simple_cls_2.las"
+    result = runner.invoke(
+        app,
+        [
+            "filter",
+            "tests/data/simple.las",
+            str(path),
+            "classification in [2, 3, 4]",
+        ],
+    )
+    assert result.exit_code == 0
+
+    las = laspy.read(path)
+    assert np.alltrue(np.isin(las.classification, [2, 3, 4]))
+
+
+def test_cli_filtering_classification_intensity(tmp_path):
+    path = tmp_path / "simple_cls_2.las"
+    result = runner.invoke(
+        app,
+        [
+            "filter",
+            "tests/data/simple.las",
+            str(path),
+            "(intensity >= 128 and intensity <= 256) and classification == 2",
+        ],
+    )
+    assert result.exit_code == 0
+
+    las = laspy.read(path)
+    assert np.all(las.classification == 2)
+    assert np.all(las.intensity >= 128)
+    assert np.all(las.intensity <= 256)
+
+
+def test_cli_filtering(tmp_path):
+    path = tmp_path / "simple_cls_2.las"
+    result = runner.invoke(
+        app,
+        [
+            "filter",
+            "tests/data/simple.las",
+            str(path),
+            "intensity <= 42 and not classification == 2",
+        ],
+    )
+    assert result.exit_code == 0
+
+    las = laspy.read(path)
+    assert np.all(las.intensity <= 42)
+    assert np.all(las.classification != 2)

--- a/tests/cli/test_info.py
+++ b/tests/cli/test_info.py
@@ -1,20 +1,16 @@
 import pytest
 
-try:
-    from typer.testing import CliRunner
+from . import skip_if_cli_deps_are_not_installed
 
-    runner = CliRunner()
-    from laspy.cli.core import app
+skip_if_cli_deps_are_not_installed()
 
-    HAS_CLI = True
-except ModuleNotFoundError:
-    HAS_CLI = False
+from typer.testing import CliRunner
+
+from laspy.cli.core import app
+
+runner = CliRunner()
 
 
-@pytest.mark.skipif(
-    not HAS_CLI,
-    reason="Dependencies for CLI are not installed",
-)
 def test_header_info():
     result = runner.invoke(app, ["info", "--header", "tests/data/simple.las"])
     assert result.exit_code == 0
@@ -42,10 +38,6 @@ def test_header_info():
     assert output == expected
 
 
-@pytest.mark.skipif(
-    not HAS_CLI,
-    reason="Dependencies for CLI are not installed",
-)
 def test_vlr_info():
     result = runner.invoke(app, ["info", "--vlrs", "tests/data/simple.las"])
     assert result.exit_code == 0
@@ -64,10 +56,6 @@ def test_vlr_info():
     assert result.stdout == expected
 
 
-@pytest.mark.skipif(
-    not HAS_CLI,
-    reason="Dependencies for CLI are not installed",
-)
 def test_info_non_existant_file():
     result = runner.invoke(
         app, ["info", "--header", "tests/data/this_does_not_exist.las"]

--- a/tests/cli/test_info.py
+++ b/tests/cli/test_info.py
@@ -10,50 +10,103 @@ from laspy.cli.core import app
 
 runner = CliRunner()
 
+EXPECTED_HEADER_INFO_SIMPLE_LAS = (
+    "                                 Header                                  \n"
+    " Version                     1.2                                         \n"
+    " Point Format Id             3                                           \n"
+    " Point Format Size           34                                          \n"
+    " Extra Bytes                 0                                           \n"
+    " Point Count                 1065                                        \n"
+    " Compressed                  False                                       \n"
+    " System Identifier           ''                                          \n"
+    " Generating Software         'TerraScan'                                 \n"
+    " Number Of VLRs              0                                           \n"
+    " UUID                        '00000000-0000-0000-0000-000000000000'      \n"
+    " File Source Id              0                                           \n"
+    " Creation Date               None                                        \n"
+    " Scales                      [0.01 0.01 0.01]                            \n"
+    " Offsets                     [-0. -0. -0.]                               \n"
+    " Mins                        [6.3561985e+05 8.4889970e+05 4.0659000e+02] \n"
+    " Maxs                        [6.3898255e+05 8.5353543e+05 5.8638000e+02] \n"
+    " Number Of Points By Return  [925 114  21   5   0]                       \n"
+)
+
+EXPECTED_VLR_INFO_SIMPLE_LAS = ""
+
+EXPECTED_POINTS_INFO_SIMPLE_LAS = (
+    "\n"
+    "                    Stats                     \n"
+    " Dimension Name       Min  Max                \n"
+    " X                    0    63898255           \n"
+    " Y                    0    85353543           \n"
+    " Z                    0    58638              \n"
+    " intensity            0    254                \n"
+    " return_number        0    4                  \n"
+    " number_of_returns    0    4                  \n"
+    " scan_direction_flag  0    1                  \n"
+    " edge_of_flight_line  0    0                  \n"
+    " classification       0    2                  \n"
+    " synthetic            0    0                  \n"
+    " key_point            0    0                  \n"
+    " withheld             0    0                  \n"
+    " scan_angle_rank      -19  18                 \n"
+    " user_data            0    149                \n"
+    " point_source_id      0    7334               \n"
+    " gps_time             0.0  249783.16215837188 \n"
+    " red                  0    249                \n"
+    " green                0    239                \n"
+    " blue                 0    249                \n"
+)
+
+EXPECTED_INFO_SIMPLE_LAS = (
+    f"{EXPECTED_HEADER_INFO_SIMPLE_LAS}"
+    "--------------------------------------------------\n"
+    f"{EXPECTED_VLR_INFO_SIMPLE_LAS}"
+    "--------------------------------------------------\n"
+    f"{EXPECTED_POINTS_INFO_SIMPLE_LAS}"
+)
+
+EXPECTED_VLR_INFO_AUTZEN_LAS = (
+    "                            VLRs                            \n"
+    " User ID          Record ID  Description                    \n"
+    " liblas           2112       OGR variant of OpenGIS WKT SRS \n"
+    " LASF_Projection  34735      GeoTIFF GeoKeyDirectoryTag     \n"
+    " LASF_Projection  34737      GeoTIFF GeoAsciiParamsTag      \n"
+    " liblas           2112       OGR variant of OpenGIS WKT SRS \n"
+)
+
 
 def test_header_info():
     result = runner.invoke(app, ["info", "--header", "tests/data/simple.las"])
     assert result.exit_code == 0
-    expected = """                                 Header                                  
- Version                     1.2                                         
- Point Format Id             3                                           
- Point Format Size           34                                          
- Extra Bytes                 0                                           
- Point Count                 1065                                        
- Compressed                  False                                       
- System Identifier           ''                                          
- Generating Software         'TerraScan'                                 
- Number Of VLRs              0                                           
- UUID                        '00000000-0000-0000-0000-000000000000'      
- File Source Id              0                                           
- Creation Date               None                                        
- Scales                      [0.01 0.01 0.01]                            
- Offsets                     [-0. -0. -0.]                               
- Mins                        [6.3561985e+05 8.4889970e+05 4.0659000e+02] 
- Maxs                        [6.3898255e+05 8.5353543e+05 5.8638000e+02] 
- Number Of Points By Return  [925 114  21   5   0]                       
-"""
 
     output = result.stdout
-    assert output == expected
+    assert output == EXPECTED_HEADER_INFO_SIMPLE_LAS
 
 
 def test_vlr_info():
     result = runner.invoke(app, ["info", "--vlrs", "tests/data/simple.las"])
     assert result.exit_code == 0
-    expected = """"""
-    assert result.stdout == expected
+    assert result.stdout == EXPECTED_VLR_INFO_SIMPLE_LAS
 
     result = runner.invoke(app, ["info", "--vlrs", "tests/data/autzen.las"])
     assert result.exit_code == 0
-    expected = """                            VLRs                            
- User ID          Record ID  Description                    
- liblas           2112       OGR variant of OpenGIS WKT SRS 
- LASF_Projection  34735      GeoTIFF GeoKeyDirectoryTag     
- LASF_Projection  34737      GeoTIFF GeoAsciiParamsTag      
- liblas           2112       OGR variant of OpenGIS WKT SRS 
-"""
-    assert result.stdout == expected
+
+    assert result.stdout == EXPECTED_VLR_INFO_AUTZEN_LAS
+
+
+def test_point_info():
+    result = runner.invoke(app, ["info", "--points", "tests/data/simple.las"])
+    assert result.exit_code == 0
+
+    assert result.stdout == EXPECTED_POINTS_INFO_SIMPLE_LAS
+
+
+def test_complete_info():
+    result = runner.invoke(app, ["info", "tests/data/simple.las"])
+    assert result.exit_code == 0
+
+    assert result.stdout == EXPECTED_INFO_SIMPLE_LAS
 
 
 def test_info_non_existant_file():

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -19,6 +19,10 @@ plane_laz = conftest.PLANE_LAZ_FILE_PATH
 autzen_las = conftest.AUTZEN_FILE_PATH
 autzen_geo_proj_las = conftest.AUTZEN_GEO_PROJ_FILE_PATH
 
+skip_if_no_laz_backend = pytest.mark.skipif(
+    len(laspy.LazBackend.detect_available()) == 0, reason="No Laz Backend installed"
+)
+
 if not laspy.LazBackend.detect_available():
     do_compression = [False]
     all_file_paths = [simple_las, vegetation1_3_las, test1_4_las, extra_bytes_las]

--- a/tests/test_reading_1_2.py
+++ b/tests/test_reading_1_2.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 import laspy
-from tests.test_common import simple_las, simple_laz
+from tests.test_common import simple_las, simple_laz, skip_if_no_laz_backend
 
 
 @pytest.fixture(
@@ -178,9 +178,7 @@ def test_blue(read_simple):
     assert f.blue.min() == 56
 
 
-@pytest.mark.skipif(
-    len(laspy.LazBackend.detect_available()) == 0, reason="No Laz Backend installed"
-)
+@skip_if_no_laz_backend
 def test_decompression_is_same_as_uncompressed():
     u_las = laspy.read(simple_las)
     c_las = laspy.read(simple_laz)


### PR DESCRIPTION
This command allows to apply so simple filters on LAS/LAZ files to get new file(s) that only contain points satisfying the filter expression.

The filter expression is a very simple string:

`classification == 2`
`classification == 2 or classification == 3`

- [x] support `not`
- [x] support `!` as `not`, `&&` as `and`, `||` as `or`
- [x] more tests
- [x] translation of pdal names