### PR TITLE
Update lazrs to remove laz Appende logic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
             "rangehttpserver",
             "isort==5.11.5",
         ],
-        "lazrs": ["lazrs>=0.5.0, < 0.6.0"],
+        "lazrs": ["lazrs>=0.6.0, < 0.7.0"],
         "laszip": ["laszip >= 0.2.1, < 0.3.0"],
         "pyproj": ["pyproj"],
         "requests": ["requests"],

--- a/tests/test_append_mode.py
+++ b/tests/test_append_mode.py
@@ -65,7 +65,6 @@ def append_self_and_check(las_path_fixture):
     with open(las_path_fixture, mode="rb") as f:
         file = io.BytesIO(f.read())
     las = laspy.read(las_path_fixture)
-    print(las.vlrs)
     with laspy.open(file, mode="a", closefd=False) as laz_file:
         laz_file.append_points(las.points)
     file.seek(0, io.SEEK_SET)


### PR DESCRIPTION
The logic of appending to a LAZ file
was integrated into lazrs.

So this updates to the latests laz-rs
to remove the logic from laspy