### PR TITLE
Numpy 2.0 updates

### DIFF
--- a/docs/basic.rst
+++ b/docs/basic.rst
@@ -154,7 +154,7 @@ To access point records using the dimension name, you have 2 options:
 
 >>> import numpy as np
 >>> las = laspy.read('tests/data/simple.las')
->>> np.all(las.user_data == las['user_data'])
+>>> bool(np.all(las.user_data == las['user_data']))
 True
 
 Point Format

--- a/laspy/lasdata.py
+++ b/laspy/lasdata.py
@@ -76,7 +76,7 @@ class LasData:
         2
         >>> xyz.shape
         (1065, 3)
-        >>> np.all(xyz[..., 0] == las.x)
+        >>> bool(np.all(xyz[..., 0] == las.x))
         True
         """
         return np.vstack((self.x, self.y, self.z)).transpose()

--- a/laspy/point/dims.py
+++ b/laspy/point/dims.py
@@ -677,9 +677,15 @@ class SubFieldView(ArrayView):
             raise OverflowError(
                 f"value {np.max(value)} is greater than allowed (max: {self.max_value_allowed})"
             )
-        value = np.array(value, copy=False).astype(self.array.dtype)
+        # value = np.array(value, copy=False).astype(self.array.dtype)
+        value = np.asarray(value)
         self.array[key] &= ~self.bit_mask
-        self.array[key] |= value << self.lsb
+
+        # This is not allowed without a casting="unsafe" argument
+        # in Numpy 2.0
+        # self.array[key] |= shifted
+        shifted = value << self.lsb
+        self.array[key] = np.bitwise_or(self.array[key], shifted, casting="unsafe")
 
     def __getitem__(self, item):
         sliced = SubFieldView(self.array[item], int(self.bit_mask))

--- a/laspy/point/dims.py
+++ b/laspy/point/dims.py
@@ -677,7 +677,6 @@ class SubFieldView(ArrayView):
             raise OverflowError(
                 f"value {np.max(value)} is greater than allowed (max: {self.max_value_allowed})"
             )
-        # value = np.array(value, copy=False).astype(self.array.dtype)
         value = np.asarray(value)
         self.array[key] &= ~self.bit_mask
 

--- a/laspy/point/record.py
+++ b/laspy/point/record.py
@@ -53,7 +53,7 @@ class PackedPointRecord:
     >>> return_number
     <SubFieldView([0 0 0 0 0 0 0 0 0 0])>
     >>> return_number[:] = 1
-    >>> np.all(packed_point_record['return_number'] == 1)
+    >>> bool(np.all(packed_point_record['return_number'] == 1))
     True
     """
 

--- a/tests/test_laspy.py
+++ b/tests/test_laspy.py
@@ -195,8 +195,8 @@ class LasWriterTestCase(unittest.TestCase):
 
     def test_overflow_return_num(self):
         """Testing overflow handling"""
+        rn = np.array(self.FileObject.return_num, dtype=np.uint32) + 100000
         with self.assertRaises(OverflowError):
-            rn = self.FileObject.return_num + 100000
             self.FileObject.return_num = rn
 
     def test_num_returns(self):

--- a/tests/test_laspy.py
+++ b/tests/test_laspy.py
@@ -195,8 +195,8 @@ class LasWriterTestCase(unittest.TestCase):
 
     def test_overflow_return_num(self):
         """Testing overflow handling"""
-        rn = self.FileObject.return_num + 100000
         with self.assertRaises(OverflowError):
+            rn = self.FileObject.return_num + 100000
             self.FileObject.return_num = rn
 
     def test_num_returns(self):


### PR DESCRIPTION
The laspy-feedstock recently pushed a build of [laspy against Numpy 2.0](https://github.com/conda-forge/laspy-feedstock/pull/27) and a bunch of tests are were failing. These changes get everything passing with Numpy 2.0. I am depending on the CI to tell me if 1.x is still working, however.