### PR TITLE
Bugfix `copc.py` to respect 0 pts in node but >0 points in child nodes

### DIFF
--- a/laspy/copc.py
+++ b/laspy/copc.py
@@ -766,7 +766,7 @@ class CopcReader:
             level_range=level,
         )
         # print("num nodes to query:", len(nodes));
-        points = self._fetch_and_decrompress_points_of_nodes(nodes)
+        points = self._fetch_and_decompress_points_of_nodes(nodes)
 
         if bounds is not None:
             MINS = np.round(
@@ -795,7 +795,7 @@ class CopcReader:
     def level_query(self, level: Union[int, range]) -> ScaleAwarePointRecord:
         return self.query(bounds=None, level=level)
 
-    def _fetch_and_decrompress_points_of_nodes(
+    def _fetch_and_decompress_points_of_nodes(
         self, nodes_to_read: List[OctreeNode]
     ) -> ScaleAwarePointRecord:
         if not nodes_to_read:

--- a/laspy/copc.py
+++ b/laspy/copc.py
@@ -406,7 +406,7 @@ def load_octree_for_query(
             hierarchy_page.entries.update(page.entries)
             nodes_to_load.insert(0, current_node)
             continue
-        elif entry.point_count != 0:
+        elif entry.point_count >= 0:
             current_node.offset = entry.offset
             current_node.byte_size = entry.byte_size
             current_node.point_count = entry.point_count


### PR DESCRIPTION
In the `CopcReader`, there exists an interesting edge case where the `point_count` of an `entry` maybe 0 but the child nodes of the `entry` may have points. This is valid per the [COPC specification](https://copc.io/copc-specification-1.0.pdf). Screenshot below,

![image](https://github.com/user-attachments/assets/9babf255-e0d2-4dfd-b0dc-30106ddb4ce2)

For cases like these on some select COPC datasets, `CopcReader` skips nodes which have `point_count = 0` but have points in the child nodes. This is a basic attempt to fix that by recursing through child nodes even if `point_count` is 0. For my use case this correctly enables reading the points which were missing earlier.

Specifically chose `elif >= 0` instead of an `else` to handle the case wherein `point_count` maybe some other negative number due to an error, so this will silently not recurse for those

Additionally this fixes a small typo in an internal function name for consistency with other functions.