### PR TITLE
Bugfix: Changed nr. points by return to use uint64 instead of uint32

### DIFF
--- a/laspy/header.py
+++ b/laspy/header.py
@@ -232,7 +232,7 @@ class LasHeader:
 
         #: Number of points by return
         #: for las <= 1.2 only the first 5 elements matters
-        self.number_of_points_by_return: np.ndarray = np.zeros(15, dtype=np.uint32)
+        self.number_of_points_by_return: np.ndarray = np.zeros(15, dtype=np.uint64)
 
         #: The VLRS
         self._vlrs: VLRList = VLRList()
@@ -473,7 +473,7 @@ class LasHeader:
         self.start_of_first_evlr = 0
         self.number_of_evlrs = 0
         self.point_count = 0
-        self.number_of_points_by_return = np.zeros(15, dtype=np.uint32)
+        self.number_of_points_by_return = np.zeros(15, dtype=np.uint64)
 
     def update(self, points: PackedPointRecord) -> None:
         self.partial_reset()


### PR DESCRIPTION
Hello,

I recently tried to open a las file that was quite large (8,000,000,000 points), which gave me an error:
```
Traceback (most recent call last):
  File "C:\...", line 6, in <module>
    with laspy.open(las_path) as las_reader:
         ^^^^^^^^^^^^^^^^^^^^
  File "C:\...", line 148, in open_las
    return LasReader(
           ^^^^^^^^^^
  File "C:\...\site-packages\laspy\lasreader.py", line 51, in __init__
    self.header = LasHeader.read_from(source, read_evlrs=read_evlrs)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\...\site-packages\laspy\header.py", line 616, in read_from
    header.number_of_points_by_return[i] = int.from_bytes(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
OverflowError: Python int too large to convert to C long
```
This is because the numpy array used for storing the number of points per return uses uint32, whereas the las specification says this should be uint64. Because I had ~4.3bil points for return 1, this gave an overflow. Changing the datatype to uint64 would fix this.
