### PR TITLE
add support for Extra Bytes no_data, min and max, with test

### DIFF
--- a/laspy/point/dims.py
+++ b/laspy/point/dims.py
@@ -337,6 +337,7 @@ class DimensionInfo(NamedTuple):
     description: str = ""
     offsets: Optional[np.ndarray] = None
     scales: Optional[np.ndarray] = None
+    no_data: Optional[np.ndarray] = None
 
     @classmethod
     def from_extra_bytes_param(cls, params):
@@ -349,6 +350,7 @@ class DimensionInfo(NamedTuple):
             params.description,
             params.offsets,
             params.scales,
+            params.no_data,
         )
         me._validate()
         return me
@@ -474,6 +476,11 @@ class DimensionInfo(NamedTuple):
         if self.scales is not None and len(self.scales) != self.num_elements:
             raise ValueError(
                 f"len(scales) ({len(self.scales)}) is not the same as the number of elements ({self.num_elements})"
+            )
+
+        if self.no_data is not None and len(self.no_data) != self.num_elements:
+            raise ValueError(
+                f"len(no_data) ({len(self.no_data)}) is not the same as the number of elements ({self.num_elements})"
             )
 
 

--- a/laspy/point/format.py
+++ b/laspy/point/format.py
@@ -19,6 +19,7 @@ class ExtraBytesParams:
         description: str = "",
         offsets: Optional[Iterable[Number]] = None,
         scales: Optional[Iterable[Number]] = None,
+        no_data: Optional[Iterable[Number]] = None,
     ) -> None:
         self.name = name
         """ The name of the extra dimension """
@@ -37,6 +38,8 @@ class ExtraBytesParams:
         """ The offsets to use if its a 'scaled dimension', can be none """
         self.scales = np.array(scales) if scales is not None else scales
         """ The scales to use if its a 'scaled dimension', can be none """
+        self.no_data = np.array(no_data) if no_data is not None else no_data
+        """ The no data values, can be none """
 
 
 class PointFormat:


### PR DESCRIPTION
This PR is a fix #340.

It modifies `ExtraByteStruct` to have:
- the parser of nodata, min and max correct (i.e. converting first in "long" types before the variable type, as specified in LAS 1.4 specs)
- a setter for property `no_data`
- a method `grow` called by `laspy.header.grow`, to grow min/max at the same time as x, y, z

I added test `test_scaled_extra_byte_min_max` that tests on an array of extra bytes.