### PR TITLE
fix: unused m2r2 causes import issues

### DIFF
--- a/laspy/vlrs/known.py
+++ b/laspy/vlrs/known.py
@@ -12,7 +12,6 @@ from copy import copy
 from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union
 
 import numpy as np
-from m2r2 import options
 
 from ..extradims import get_dtype_for_extra_dim
 from ..point.dims import ScaledArrayView


### PR DESCRIPTION
Fixes #348 

The unsused module `m2r2` is causing import errors in the released 2.6.0 version of laspy. It is a dev dependency only and the `m2r2` module was probably added by auto-import tooling and commited by mistake.