### PR TITLE
Fix LasHeader default format getting modified class-wise when adding fields to an instance

### DIFF
--- a/laspy/header.py
+++ b/laspy/header.py
@@ -195,7 +195,7 @@ class LasHeader:
 
         if version is None and point_format is None:
             version = LasHeader.DEFAULT_VERSION
-            point_format = LasHeader.DEFAULT_POINT_FORMAT
+            point_format = deepcopy(LasHeader.DEFAULT_POINT_FORMAT)
         elif version is not None and point_format is None:
             point_format = PointFormat(dims.min_point_format_for_version(str(version)))
         elif version is None and point_format is not None:


### PR DESCRIPTION
First of all, thank you for your hard work, the laspy package is indispensable to my everyday work.

In the current code, LasHeader's default format is defined like this:

https://github.com/laspy/laspy/blob/07a5fa40ebbf8eb638ea5fe7d0c772405ea600c6/laspy/header.py#L170

Which is a reference to a mutable object. When we create a LasHeader **instance** without specifying a point format, its format becomes the LasHeader **class** attribute instance of PointFormat.

https://github.com/laspy/laspy/blob/07a5fa40ebbf8eb638ea5fe7d0c772405ea600c6/laspy/header.py#L196-L198

This leads to the unexpected behavior, that adding new scalar fields via add_extra_dims modifies the class and not just the instance, meaning any LasHeader objects instantiated afterwards, will have the same new scalar fields.

```
>>> import laspy
>>> las = laspy.LasData(laspy.LasHeader())
>>> las.add_extra_dim(laspy.ExtraBytesParams(name='testfield', type='float'))
>>> las2 = laspy.LasData(laspy.LasHeader())
>>> las2.add_extra_dim(laspy.ExtraBytesParams(name='testfield', type='float'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/kasparas/miniconda3/envs/las/lib/python3.10/site-packages/laspy/lasdata.py", line 135, in add_extra_dim
    self.add_extra_dims([params])
  File "/home/kasparas/miniconda3/envs/las/lib/python3.10/site-packages/laspy/lasdata.py", line 146, in add_extra_dims
    new_point_record = record.ScaleAwarePointRecord.zeros(
  File "/home/kasparas/miniconda3/envs/las/lib/python3.10/site-packages/laspy/point/record.py", line 337, in zeros
    data = np.zeros(point_count, point_format.dtype())
  File "/home/kasparas/miniconda3/envs/las/lib/python3.10/site-packages/laspy/point/format.py", line 232, in dtype
    return np.dtype(descr)
ValueError: field 'testfield' occurs more than once
```

This is not a super common scenario, but in the case where new point clouds are created in a loop, and not all of them share the same scalar field names, creating a single header and passing it around is not practical.

If this is not intended behavior, this pull request fixes that issue by creating a copy of the default PointFormat instance.


