### PR TITLE
Add support for 1.5

### DIFF
--- a/laspy/point/dims.py
+++ b/laspy/point/dims.py
@@ -266,6 +266,7 @@ VERSION_TO_POINT_FMT: Dict[str, Tuple[int, ...]] = {
     "1.2": (0, 1, 2, 3),
     "1.3": (0, 1, 2, 3, 4, 5),
     "1.4": (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
+    "1.5": (6, 7, 8, 9, 10),
 }
 
 POINT_FORMATS_DTYPE = PointFormatDict(

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     long_description=readme,
     long_description_content_type="text/markdown",
     packages=find_packages(exclude=("tests", "tests.cli")),
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     install_requires=["numpy"],
     extras_require={
         "dev": [
@@ -38,7 +38,7 @@ setup(
             "isort==7.0.0",
         ],
         "lazrs": ["lazrs>=0.7.0, < 0.8.0"],
-        "laszip": ["laszip >= 0.2.1, < 0.3.0"],
+        "laszip": ["laszip >= 0.3.0, < 0.4.0"],
         "pyproj": ["pyproj"],
         "requests": ["requests"],
         "cli": [

--- a/tests/test_1_5.py
+++ b/tests/test_1_5.py
@@ -1,0 +1,67 @@
+import io
+
+import numpy as np
+import pytest
+
+import laspy
+
+
+def test_convert_1_5_write_read_las():
+    las = laspy.read("tests/data/simple.las")
+
+    for fmt in range(6):
+        with pytest.raises(laspy.LaspyException):
+            converted = laspy.convert(las, point_format_id=fmt, file_version="1.5")
+
+    with io.BytesIO() as stream:
+        for fmt in range(6, 11):
+            stream.seek(0)
+            converted = laspy.convert(las, point_format_id=fmt, file_version="1.5")
+            converted.write(stream, do_compress=False)
+            stream.seek(0)
+
+            las2 = laspy.read(stream, closefd=False)
+            assert np.allclose(las2.header.max_gps_time, las.gps_time.max())
+            assert np.allclose(las2.header.min_gps_time, las.gps_time.min())
+
+            for dim_name in las2.point_format.dimension_names:
+                try:
+                    expected = las[dim_name]
+                except ValueError:
+                    # The dimension may not exist in the old point format
+                    continue
+
+                assert np.allclose(
+                    las2[dim_name], expected
+                ), f"Dimenion {dim_name} is not as expected"
+
+
+@pytest.mark.parametrize("laz_backend", laspy.LazBackend.detect_available())
+def test_convert_1_5_write_read_laz(laz_backend):
+    las = laspy.read("tests/data/simple.las")
+
+    for fmt in range(6):
+        with pytest.raises(laspy.LaspyException):
+            converted = laspy.convert(las, point_format_id=fmt, file_version="1.5")
+
+    with io.BytesIO() as stream:
+        for fmt in range(6, 11):
+            stream.seek(0)
+            converted = laspy.convert(las, point_format_id=fmt, file_version="1.5")
+            converted.write(stream, do_compress=True, laz_backend=laz_backend)
+            stream.seek(0)
+
+            las2 = laspy.read(stream, closefd=False)
+            assert np.allclose(las2.header.max_gps_time, las.gps_time.max())
+            assert np.allclose(las2.header.min_gps_time, las.gps_time.min())
+
+            for dim_name in las2.point_format.dimension_names:
+                try:
+                    expected = las[dim_name]
+                except ValueError:
+                    # The dimension may not exist in the old point format
+                    continue
+
+                assert np.allclose(
+                    las2[dim_name], expected
+                ), f"Dimenion {dim_name} is not as expected"


### PR DESCRIPTION
# TODO
- [x] Tests
  - [x] Read
  - [x] Write
  - [x] Convert
- [x] Enforce no PDRF < 6 in LasData when version is 1.5 ?
