### PR TITLE
Fix CLI dependencies: remove invalid typer[all] extra and bump minimum Typer version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         "pyproj": ["pyproj"],
         "requests": ["requests"],
         "cli": [
-            "typer[all] >= 0.8.0 ",
+            "typer >= 0.16.0 ",
             "rich >= 10.11.0",
         ],
     },


### PR DESCRIPTION
This PR updates the `cli` extra dependencies to reflect actual runtime requirements of the laspy CLI:

* Removes the invalid `typer[all]` extra (no longer published upstream)
* Bumps the minimum supported Typer version to `>= 0.16.0`, the lowest version observed to work reliably

#### Background

Historically, Typer 0.8 defined an `all` extra, but this extra has been removed in later Typer releases. As a result, depending on `typer[all] >= 0.8.0` now produces warnings in dependency resolvers (e.g. `uv sync`) because the extra no longer exists.

While investigating this, I also tested the laspy CLI against older Typer versions and found that versions **prior to 0.16.0 exhibit broken or severely degraded CLI behavior**. This indicates that the existing constraint (`typer >= 0.8.0`) is too permissive and allows installations with a non-functional CLI.

For example, with Typer 0.15.x, even running `laspy --help` fails with a runtime error:

```
TypeError: Parameter.make_metavar() missing 1 required positional argument: 'ctx'
```