### PR TITLE
fix: replace bare except with except Exception in open_las

### DIFF
--- a/laspy/lib.py
+++ b/laspy/lib.py
@@ -157,7 +157,7 @@ def open_las(
                 decompression_selection=decompression_selection,
                 waveform_mode=waveform_mode,
             )
-        except:
+        except Exception:
             if closefd:
                 stream.close()
             raise
@@ -184,7 +184,7 @@ def open_las(
                 closefd=closefd,
                 encoding_errors=encoding_errors,
             )
-        except:
+        except Exception:
             if closefd:
                 stream.close()
             raise
@@ -203,7 +203,7 @@ def open_las(
                 laz_backend=laz_backend,
                 encoding_errors=encoding_errors,
             )
-        except:
+        except Exception:
             if closefd:
                 stream.close()
             raise


### PR DESCRIPTION
## Description

Replaces 3 bare `except:` clauses in `laspy/lib.py`'s `open_las()` function with `except Exception:`.

## Why

Bare `except:` clauses catch **all** exceptions, including `BaseException`-derived classes like `KeyboardInterrupt` and `SystemExit`. This can:

1. Prevent clean program termination on Ctrl+C
2. Catch exceptions that should propagate up to the interpreter
3. Make the code's intent unclear (is it catching errors or signals?)

The intent of the existing code is clear: if the `LasReader`/`LasWriter`/`LasAppender` constructor fails, close the stream and re-raise. This is application-level error handling, so `Exception` is the right base class.

## Pattern Consistency

This also matches the existing pattern used throughout the codebase:
- `laspy/lasreader.py`: `except Exception as e:`
- `laspy/laswriter.py`: `except Exception as e:`
- `laspy/lasappender.py`: `except Exception as e:`

## Diff

```diff
-        except:
+        except Exception:
             if closefd:
                 stream.close()
             raise
```

(3 occurrences, in the `r`, `w`, and `a` mode branches)

— Sent via @AmSach bot