### PR TITLE
Fix length-two fancy indexing for scaled arrays

### DIFF
--- a/laspy/point/dims.py
+++ b/laspy/point/dims.py
@@ -768,7 +768,7 @@ class ScaledArrayView(ArrayView):
             return self.__class__(self.array[item], self.scale, self.offset)
         else:
             sliced_array = self.array[item]
-            if len(item) == 2:
+            if isinstance(item, tuple) and len(item) == 2:
                 if item[1] is Ellipsis:
                     # item is (index, ...), it queries for all the dimensions
                     # of a point or set of point, so we don't slice the scales/offsets
@@ -805,12 +805,7 @@ class ScaledArrayView(ArrayView):
         if isinstance(value, ScaledArrayView):
             value = np.array(value)
 
-        try:
-            key_len = len(key)
-        except TypeError:
-            key_len = 1
-
-        if key_len == 2:
+        if isinstance(key, tuple) and len(key) == 2:
             self.array[key] = self._remove_scale(value, sub=key[1])
         else:
             self.array[key] = self._remove_scale(value)

--- a/tests/test_field_views.py
+++ b/tests/test_field_views.py
@@ -103,6 +103,29 @@ def test_scaled_array_view_indexing_with_array_or_list(simple_las_path):
     assert np.all(d == d2)
 
 
+@pytest.mark.parametrize(
+    "index",
+    [np.array([True, False]), np.array([1, 0]), [1, 0], np.array([1, 1])],
+    ids=["boolean-mask", "integer-ndarray", "integer-list", "repeated-index"],
+)
+def test_scaled_array_view_length_two_fancy_indexing(index):
+    view = ScaledArrayView(
+        np.array([10, 20], np.int32), np.float64(0.5), np.float64(1.0)
+    )
+
+    np.testing.assert_array_equal(np.asarray(view[index]), np.asarray(view)[index])
+
+
+def test_scaled_array_view_length_two_fancy_assignment():
+    view = ScaledArrayView(
+        np.array([10, 20], np.int32), np.float64(0.5), np.float64(1.0)
+    )
+
+    view[np.array([True, False])] = [7.0]
+
+    np.testing.assert_array_equal(np.asarray(view), [7.0, 11.0])
+
+
 def test_sub_field_view_with_self(simple_las_path):
     las = laspy.read(simple_las_path)
 


### PR DESCRIPTION
Fixes #372.

## Summary

`ScaledArrayView` treated every index with length two as a two-dimensional tuple. One-dimensional boolean masks, NumPy integer arrays, and Python integer lists of length two therefore selected the wrong scale/offset or raised an exception.

## Changes

- Restrict the two-dimensional scale/offset path to actual two-element tuples in both `__getitem__` and `__setitem__`.
- Add NumPy-oracle regressions for length-two boolean and integer fancy reads.
- Add a regression for length-two boolean fancy assignment.

## Testing

- RED on the exact upstream base: `5 failed, 10 passed`
- Focused final test file: `15 passed`
- Adjacent point-record/point-format tests: `34 passed, 1 skipped`
- Full repository suite: `651 passed, 134 skipped`
- Black 25.12.0: 88 files unchanged
- isort 7.0.0 and `git diff --check`: passed

## AI-use disclosure

This pull request was prepared and opened by OpenAI Codex acting as an automated contributor under the account owner's authorization. Codex generated the code and tests, independently rechecked the issue, repository policy, and duplicate state, and ran the validation listed above. The final diff was reviewed for minimal scope and is limited to the two symmetric index-dispatch checks plus regression coverage.
