### PR TITLE
Fix #370: CopcReader.query() with 2D bounds uses header Z-extent, causing point loss

### DIFF
--- a/laspy/copc.py
+++ b/laspy/copc.py
@@ -756,7 +756,9 @@ class CopcReader:
             level = range(level, level + 1)
 
         if bounds is not None:
-            bounds = bounds.ensure_3d(self.header.mins, self.header.maxs)
+            cube_mins = self.copc_info.center - self.copc_info.halfsize
+            cube_maxs = self.copc_info.center + self.copc_info.halfsize
+            bounds = bounds.ensure_3d(cube_mins, cube_maxs)
 
         nodes = load_octree_for_query(
             self.source,


### PR DESCRIPTION
Fixes #370

## Problem

CopcReader.query(bounds) with 2D Bounds silently returns only a tiny fraction of the points when the file actual Z-range is much smaller than the COPC octree cube Z-extent.

## Root Cause

ensure_3d() fills missing Z from LAS header data extent, but octree nodes use cube extent for overlap checks. When data Z (e.g. 180m terrain) << cube Z (e.g. 4636m), deep nodes are incorrectly pruned.

## Fix

Use octree cube Z-extent instead of header Z-extent in ensure_3d(). 3-line change in copc.py. 3D queries unaffected since ensure_3d preserves existing Z.

## Testing

- All 10 existing tests pass (5 skipped as expected)
- 2D query now returns same point count as 3D full-cube-Z query