### PR TITLE
Add support of compound CRS for geotiff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Support for compound CRS (horizontal + vertical) when writing GeoTIFF VLRs
+  with `LasHeader.add_crs`. The vertical component is stored as a
+  `VerticalCSTypeGeoKey` and read back by `parse_crs` as a compound CRS.
+
 ## Version 2.7.0 (14/01/2026)
 
 ### Added

--- a/laspy/vlrs/geotiff.py
+++ b/laspy/vlrs/geotiff.py
@@ -97,6 +97,24 @@ PCSCitationGeoKey = GeoKeyEntryStruct(
     tiff_tag_location=GeoAsciiParamsVlr.official_record_ids()[0],
 )
 
+# Vertical CS Parameter GeoKeys
+
+VerticalCSTypeGeoKey = GeoKeyEntryStruct(
+    id=4096,
+    tiff_tag_location=0,
+    count=1,
+)
+
+"""
+Units used for the vertical coordinate system.
+http://geotiff.maptools.org/spec/geotiff6.html#6.3.4.1
+"""
+VerticalUnitsGeoKey = GeoKeyEntryStruct(
+    id=4099,
+    tiff_tag_location=0,
+    count=1,
+)
+
 # Geographic CS Parameter GeoKeys
 
 
@@ -105,6 +123,34 @@ def create_geotiff_projection_vlrs(
 ) -> Tuple[GeoKeyDirectoryVlr, GeoAsciiParamsVlr]:
     # 'Cookbook' from the geotiff spec
     # http://geotiff.maptools.org/spec/geotiff2.7.html#2.7
+
+    if crs.is_compound:
+        horizontal_crs = next(
+            (
+                s
+                for s in crs.sub_crs_list
+                if s.is_projected or s.is_geographic or s.is_geocentric
+            ),
+            None,
+        )
+        vertical_crs = next(
+            (s for s in crs.sub_crs_list if s.is_vertical),
+            None,
+        )
+        if horizontal_crs is None:
+            raise RuntimeError("Compound CRS has no recognized horizontal component")
+
+        geo_key_vlr, ascii_vlr = create_geotiff_projection_vlrs(horizontal_crs)
+
+        if vertical_crs is not None:
+            vert_epsg = vertical_crs.to_epsg()
+            if vert_epsg is not None:
+                vert_cs_key = copy(VerticalCSTypeGeoKey)
+                vert_cs_key.value_offset = vert_epsg
+                geo_key_vlr.geo_keys = list(geo_key_vlr.geo_keys) + [vert_cs_key]
+                geo_key_vlr.geo_keys_header.number_of_keys = len(geo_key_vlr.geo_keys)
+
+        return geo_key_vlr, ascii_vlr
 
     if crs.is_projected:
         model_key = copy(GTModelTypeGeoKey)

--- a/laspy/vlrs/known.py
+++ b/laspy/vlrs/known.py
@@ -698,10 +698,15 @@ class GeoKeyDirectoryVlr(BaseKnownVLR):
 
         # TODO import is done here to avoid cyclic import,
         # this should probably be fixed
-        from .geotiff import GeographicTypeGeoKey, ProjectedCSTypeGeoKey
+        from .geotiff import (
+            GeographicTypeGeoKey,
+            ProjectedCSTypeGeoKey,
+            VerticalCSTypeGeoKey,
+        )
 
         geographic_cs = None
         projected_cs = None
+        vertical_cs = None
         for key in self.geo_keys:
             if key.id == ProjectedCSTypeGeoKey.id:
                 if 1024 <= key.value_offset <= 32766:
@@ -713,12 +718,29 @@ class GeoKeyDirectoryVlr(BaseKnownVLR):
                 # GeodeticCRSGeoKey values in the range 1024-32766 SHALL be EPSG geographic 2D or geocentric CRS codes
                 if 1024 <= key.value_offset <= 32766:
                     geographic_cs = pyproj.CRS.from_epsg(key.value_offset)
+            elif key.id == VerticalCSTypeGeoKey.id:
+                # http://docs.opengeospatial.org/is/19-008r4/19-008r4.html#_requirements_class_verticalgeokey
+                # "VerticalGeoKey values in the range 1024-32766 SHALL be EPSG Vertical CRS Codes"
+                if 1024 <= key.value_offset <= 32766:
+                    vertical_cs = pyproj.CRS.from_epsg(key.value_offset)
 
         # Projected Coordinate Systems take precedence since,
         # if they are present, the Geographic CS is probably
         # redundant and the positioning information in the LAS
         # file is projected.
-        return projected_cs or geographic_cs
+        horizontal_cs = projected_cs or geographic_cs
+
+        # When a vertical CRS is also present, combine both components into a
+        # compound CRS to reflect the full georeferencing information.
+        if horizontal_cs is not None and vertical_cs is not None:
+            return pyproj.CRS(
+                pyproj.crs.CompoundCRS(
+                    name="{} + {}".format(horizontal_cs.name, vertical_cs.name),
+                    components=[horizontal_cs, vertical_cs],
+                )
+            )
+
+        return horizontal_cs
 
     def __repr__(self):
         return "<{}({} geo_keys)>".format(self.__class__.__name__, len(self.geo_keys))

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -7,7 +7,11 @@ from typing import Dict
 import pytest
 
 import laspy
-from laspy.vlrs.geotiff import GeographicTypeGeoKey, ProjectedCSTypeGeoKey
+from laspy.vlrs.geotiff import (
+    GeographicTypeGeoKey,
+    ProjectedCSTypeGeoKey,
+    VerticalCSTypeGeoKey,
+)
 from laspy.vlrs.known import GeoKeyDirectoryVlr
 from tests.test_common import autzen_geo_proj_las, autzen_las, test1_4_las
 
@@ -194,6 +198,66 @@ def test_pdal_understands_our_geotiff_geographic_cs():
 def test_pdal_understands_our_geotiff_projected_cs():
     crs = pyproj.CRS.from_epsg(6432)
     geotiff_crs_pdal_test(crs)
+
+
+@pytest.mark.skipif(not has_pyproj(), reason="pyproj not installed")
+def test_add_crs_geotiff_compound_projected():
+    """
+    Test that a compound CRS (projected + vertical) stores the horizontal
+    ProjectedCSTypeGeoKey and VerticalCSTypeGeoKey.
+    EPSG:5555 = ETRS89 / UTM zone 32N + DHHN92 height
+    """
+    crs = pyproj.CRS.from_epsg(5555)
+    header = laspy.LasHeader(point_format=3, version="1.2")
+    header.add_crs(crs)
+
+    geokeys = get_geokeys(header)
+
+    # Horizontal component: ETRS89 / UTM zone 32N = EPSG:25832
+    assert geokeys[ProjectedCSTypeGeoKey.id] == 25832
+    # Vertical component: DHHN92 height = EPSG:5783
+    assert geokeys[VerticalCSTypeGeoKey.id] == 5783
+
+
+@pytest.mark.skipif(not has_pyproj(), reason="pyproj not installed")
+def test_add_crs_geotiff_compound_geographic():
+    """
+    Test that a compound CRS (geographic + vertical) stores the horizontal
+    GeographicTypeGeoKey and VerticalCSTypeGeoKey.
+    EPSG:9707 = WGS 84 + EGM96 height
+    """
+    crs = pyproj.CRS.from_epsg(9707)
+    header = laspy.LasHeader(point_format=3, version="1.2")
+    header.add_crs(crs)
+
+    geokeys = get_geokeys(header)
+
+    # Horizontal component: WGS 84 = EPSG:4326
+    assert geokeys[GeographicTypeGeoKey.id] == 4326
+    # Vertical component: EGM96 height = EPSG:5773
+    assert geokeys[VerticalCSTypeGeoKey.id] == 5773
+
+
+@pytest.mark.skipif(not has_pyproj(), reason="pyproj not installed")
+def test_add_crs_geotiff_compound_roundtrip():
+    """
+    Test that the vertical GeoKeys survive a write/read cycle and that
+    ``parse_crs`` reconstructs the compound CRS.
+    """
+    crs = pyproj.CRS.from_epsg(5555)
+    header = laspy.LasHeader(point_format=3, version="1.2")
+    header.add_crs(crs)
+
+    las = laspy.LasData(header=header)
+    las = laspy.lib.write_then_read_again(las)
+
+    geokeys = get_geokeys(las.header)
+    assert geokeys[ProjectedCSTypeGeoKey.id] == 25832
+    assert geokeys[VerticalCSTypeGeoKey.id] == 5783
+
+    parsed = las.header.parse_crs()
+    assert parsed.is_compound
+    assert parsed == crs
 
 
 @pytest.mark.skipif(not has_pyproj(), reason="pyproj not installed")


### PR DESCRIPTION
### Context

A compound CRS combines a horizontal component with a vertical component. Previously, passing a compound `pyproj.CRS` to `header.add_crs()` on a LAS 1.4 / point format < 6 file (which uses GeoTIFF VLRs rather than WKT) would raise a `RuntimeError`, because `create_geotiff_projection_vlrs` had no handling for compound CRS objects.

### What this PR does

**Write path** (`create_geotiff_projection_vlrs`):
- Detects compound CRS objects.
- Recursively processes the horizontal component (projected / geographic / geocentric) using the existing logic.
- Appends a **`VerticalCSTypeGeoKey`** (4096) set to the EPSG code of the vertical CRS. The vertical EPSG code already implies the vertical units, so no separate `VerticalUnitsGeoKey` is emitted. The resulting GeoKeys stay sorted by key id as required by the GeoTIFF spec, and `number_of_keys` is kept in sync.

**Read path** (`GeoKeyDirectoryVlr.parse_crs`):
- Reads the `VerticalCSTypeGeoKey` back and, when both a horizontal and a vertical CRS are present, recombines them into a `pyproj` compound CRS. This keeps `add_crs` / `parse_crs` symmetric.

### Tests

Three new tests in test_crs.py:
- `test_add_crs_geotiff_compound_projected` — compound projected + vertical CRS (EPSG:5555).
- `test_add_crs_geotiff_compound_geographic` — compound geographic + vertical CRS (EPSG:9707).
- `test_add_crs_geotiff_compound_roundtrip` — verifies the vertical GeoKey survives a write/read cycle **and** that `parse_crs()` reconstructs the original compound CRS.

The output was also validated against PDAL/GDAL, which reconstructs the exact original compound CRS (EPSG:5555 and EPSG:9707).

### Scope and limitations

- Only the GeoTIFF VLR path is affected. LAS 1.4 / point format ≥ 6 files already store WKT, which natively represents compound CRS without any changes.
- If the vertical CRS has no resolvable EPSG code, the vertical GeoKey is omitted (the horizontal CRS is still written).